### PR TITLE
Major updates to matches when importing

### DIFF
--- a/hasheous/Classes/AutoMapper.cs
+++ b/hasheous/Classes/AutoMapper.cs
@@ -1,0 +1,37 @@
+using System.Data;
+using hasheous_server.Models;
+
+namespace Classes
+{
+    public class AutoMapper
+    {
+        /// <summary>
+        /// Loops all ROMs in the database and maps them to the correct data object
+        /// </summary>
+        public static void RomAutoMapper()
+        {
+            Database db = new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString);
+            string sql = "SELECT * FROM Signatures_Roms;";
+            DataTable dt = db.ExecuteCMD(sql);
+
+            foreach (DataRow row in dt.Rows)
+            {
+                Logging.Log(Logging.LogType.Information, "AutoMapper", "Mapping ROM: " + row["Name"].ToString());
+
+                // build lookup model
+                HashLookupModel hashLookupModel = new HashLookupModel();
+                if (row["MD5"] != System.DBNull.Value)
+                {
+                    hashLookupModel.MD5 = row["MD5"].ToString();
+                }
+                if (row["SHA1"] != System.DBNull.Value)
+                {
+                    hashLookupModel.SHA1 = row["SHA1"].ToString();
+                }
+
+                // search
+                HashLookup hashLookup = new HashLookup(new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString), hashLookupModel);
+            }
+        }
+    }
+}

--- a/hasheous/Classes/ProcessQueue.cs
+++ b/hasheous/Classes/ProcessQueue.cs
@@ -219,6 +219,10 @@ namespace Classes
 
                                     break;
 
+                                case QueueItemType.AutoMapper:
+                                    AutoMapper.RomAutoMapper();
+                                    break;
+
                             }
                         }
                         catch (Exception ex)
@@ -279,7 +283,12 @@ namespace Classes
             /// <summary>
             /// Fetch VIMM manual metadata
             /// </summary>
-            FetchVIMMMetadata
+            FetchVIMMMetadata,
+
+            /// <summary>
+            /// Loops all ROMs in the database and attempts to match them to a data object - or creates a new datao object if no match is found
+            /// </summary>
+            AutoMapper
         }
 
         public enum QueueItemState

--- a/hasheous/Program.cs
+++ b/hasheous/Program.cs
@@ -371,6 +371,16 @@ new ProcessQueue.QueueItem(
     }
     )
 );
+ProcessQueue.QueueItems.Add(
+new ProcessQueue.QueueItem(
+    ProcessQueue.QueueItemType.AutoMapper,
+    10080,
+    new List<ProcessQueue.QueueItemType>
+    {
+
+    }
+    )
+);
 
 Logging.WriteToDiskOnly = false;
 


### PR DESCRIPTION
When searching for a hash, Hasheous would search for an exact match of the related game via ID.

This change falls back to searching for the related game via parsed game name and platform. If this returns a result then the signature table is added to the existing game.

This should help reduce the incidence of duplicates.