### PR TITLE
Check that downloaded files are non-zero length and respond to the client accordingly.

### DIFF
--- a/hasheous/Controllers/V1.0/MetadataProxyController.cs
+++ b/hasheous/Controllers/V1.0/MetadataProxyController.cs
@@ -1465,6 +1465,10 @@ namespace hasheous_server.Controllers.v1_0
         public IActionResult GetTheGamesDBImage(MetadataQuery.imageSize ImageSize, string FileName)
         {
             FileName = System.Uri.UnescapeDataString(FileName);
+            if (FileName.Contains("..") || FileName.Contains("/") || FileName.Contains("\\"))
+            {
+                return BadRequest("Invalid image ID");
+            }
             string imageFile = Path.Combine(Config.LibraryConfiguration.LibraryMetadataDirectory_TheGamesDb, "Images", ImageSize.ToString(), FileName);
             string imagePath = Path.GetDirectoryName(imageFile);
 

--- a/hasheous/Controllers/V1.0/MetadataProxyController.cs
+++ b/hasheous/Controllers/V1.0/MetadataProxyController.cs
@@ -1373,6 +1373,14 @@ namespace hasheous_server.Controllers.v1_0
             // check if image exists
             if (System.IO.File.Exists(imagePath))
             {
+                // check the file is non-zero length
+                FileInfo fileInfo = new FileInfo(imagePath);
+                if (fileInfo.Length == 0)
+                {
+                    System.IO.File.Delete(imagePath);
+                    return NotFound();
+                }
+
                 return PhysicalFile(imagePath, "image/jpeg");
             }
             else
@@ -1418,6 +1426,17 @@ namespace hasheous_server.Controllers.v1_0
                         }
                     }
 
+                    if (System.IO.File.Exists(imagePath))
+                    {
+                        // check the file is non-zero length
+                        FileInfo fileInfo = new FileInfo(imagePath);
+                        if (fileInfo.Length == 0)
+                        {
+                            System.IO.File.Delete(imagePath);
+                            return NotFound();
+                        }
+                    }
+
                     return PhysicalFile(imagePath, "image/jpeg");
                 }
                 catch (Exception ex)
@@ -1458,6 +1477,14 @@ namespace hasheous_server.Controllers.v1_0
             // check if image exists
             if (System.IO.File.Exists(imageFile))
             {
+                // check the file is non-zero length
+                FileInfo fileInfo = new FileInfo(imageFile);
+                if (fileInfo.Length == 0)
+                {
+                    System.IO.File.Delete(imageFile);
+                    return NotFound();
+                }
+
                 return PhysicalFile(imageFile, "image/jpeg");
             }
             else
@@ -1474,6 +1501,14 @@ namespace hasheous_server.Controllers.v1_0
                     while (result.IsCompleted == false)
                     {
                         Thread.Sleep(1000);
+                    }
+
+                    // check the file is non-zero length
+                    FileInfo fileInfo = new FileInfo(imageFile);
+                    if (fileInfo.Length == 0)
+                    {
+                        System.IO.File.Delete(imageFile);
+                        return NotFound();
                     }
 
                     return PhysicalFile(imageFile, "image/jpeg");


### PR DESCRIPTION
Previously if an image was downloaded and there was an error resulting in a zero length file, a broken file would be returned.

This change checks if the file is greater than 0 length before returning. If the file is 0 length it's deleted and a 404 is returned.