### PR TITLE
Add Open Graph meta tags for data object detail pages

### DIFF
--- a/hasheous/wwwroot/index.html
+++ b/hasheous/wwwroot/index.html
@@ -21,6 +21,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
+    <!--OG_INJECT-->
     <title>Hasheous</title>
 </head>
 


### PR DESCRIPTION
Inject Open Graph meta tags into the HTML for data object detail pages to enhance sharing on social media platforms. Cache the generated tags using Redis if enabled.