### PR TITLE
Prevent program crash when extracting Redump files due to duplicate file names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,7 +55,7 @@
             "program": "${workspaceFolder}/service-host/bin/Debug/net8.0/service-host.dll",
             "args": [
                 "--service",
-                "SignatureIngestor",
+                "FetchRedumpMetadata",
                 "--reportingserver",
                 "https://localhost:5001"
             ],

--- a/hasheous-lib/Classes/Metadata/Redump/MetadataDownload.cs
+++ b/hasheous-lib/Classes/Metadata/Redump/MetadataDownload.cs
@@ -94,14 +94,48 @@ namespace Redump
                         // loop through all zip entries and extract all files - check for presence of existing files and rename if necessary
                         using (var archive = System.IO.Compression.ZipFile.OpenRead(cueDownloadPath))
                         {
+                            var baseDirFull = Path.GetFullPath(cueExtractDir) + Path.DirectorySeparatorChar;
                             foreach (var entry in archive.Entries)
                             {
-                                var destinationPath = Path.Combine(cueExtractDir, entry.FullName);
+                                // Skip directory entries
+                                if (string.IsNullOrEmpty(entry.Name) && (entry.FullName.EndsWith("/") || entry.FullName.EndsWith("\\")))
+                                {
+                                    continue;
+                                }
+
+                                // Normalize separators and basic traversal rejection
+                                var normalizedFullName = entry.FullName.Replace('\\', '/');
+                                if (normalizedFullName.Contains(".."))
+                                {
+                                    Logging.Log(Logging.LogType.Warning, "Redump", $"Skipping suspicious zip entry (contains ..): {entry.FullName}");
+                                    continue;
+                                }
+
+                                var destinationPath = Path.GetFullPath(
+                                    Path.Combine(cueExtractDir, normalizedFullName.Replace('/', Path.DirectorySeparatorChar))
+                                );
+
+                                // Ensure the destination stays within the extraction root (Zip Slip mitigation)
+                                if (!destinationPath.StartsWith(baseDirFull, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    Logging.Log(Logging.LogType.Warning, "Redump", $"Skipping zip entry outside target directory: {entry.FullName}");
+                                    continue;
+                                }
+
+                                // Ensure directory exists
+                                var destDir = Path.GetDirectoryName(destinationPath);
+                                if (!string.IsNullOrEmpty(destDir) && !Directory.Exists(destDir))
+                                {
+                                    Directory.CreateDirectory(destDir);
+                                }
+
+                                // If file exists, rename to avoid overwrite
                                 if (File.Exists(destinationPath))
                                 {
                                     var newFileName = $"{Path.GetFileNameWithoutExtension(entry.Name)}_{Guid.NewGuid()}{Path.GetExtension(entry.Name)}";
-                                    destinationPath = Path.Combine(cueExtractDir, newFileName);
+                                    destinationPath = Path.Combine(destDir ?? cueExtractDir, newFileName);
                                 }
+
                                 entry.ExtractToFile(destinationPath);
                             }
                         }

--- a/hasheous-lib/Classes/Metadata/Redump/MetadataDownload.cs
+++ b/hasheous-lib/Classes/Metadata/Redump/MetadataDownload.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using Classes;
 using hasheous_server.Classes;
 
@@ -90,7 +91,20 @@ namespace Redump
                         string cueExtractDir = System.IO.Path.Combine(extractDir, "cuesheets", platformName);
                         if (!Directory.Exists(cueExtractDir)) { Directory.CreateDirectory(cueExtractDir); }
                         Logging.Log(Logging.LogType.Information, "Redump", $"Extracting cuesheet for platform {platformName} to {cueExtractDir}");
-                        System.IO.Compression.ZipFile.ExtractToDirectory(cueDownloadPath, cueExtractDir);
+                        // loop through all zip entries and extract all files - check for presence of existing files and rename if necessary
+                        using (var archive = System.IO.Compression.ZipFile.OpenRead(cueDownloadPath))
+                        {
+                            foreach (var entry in archive.Entries)
+                            {
+                                var destinationPath = Path.Combine(cueExtractDir, entry.FullName);
+                                if (File.Exists(destinationPath))
+                                {
+                                    var newFileName = $"{Path.GetFileNameWithoutExtension(entry.Name)}_{Guid.NewGuid()}{Path.GetExtension(entry.Name)}";
+                                    destinationPath = Path.Combine(cueExtractDir, newFileName);
+                                }
+                                entry.ExtractToFile(destinationPath);
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
Implement a solution to handle duplicate file names during the extraction of Redump files, ensuring the program does not crash. This includes renaming files when conflicts are detected.