### PR TITLE
Remove limit clause from DataObject query for improved data retrieval

### DIFF
--- a/hasheous-lib/Classes/DataObjects.cs
+++ b/hasheous-lib/Classes/DataObjects.cs
@@ -1560,8 +1560,7 @@ namespace hasheous_server.Classes
                             DataObject_MetadataMap GROUP BY DataObjectId ORDER BY LastSearched) DDMM ON DataObject.Id = DDMM.DataObjectId
                     WHERE
                         ObjectType = @objecttype AND DDMM.LastSearched < @lastsearched
-                    ORDER BY DataObject.`Name`
-                    LIMIT 10000;
+                    ORDER BY DataObject.`Name`;
                 ";
                 dbDict = new Dictionary<string, object>{
                     { "objecttype", objectType },

--- a/service-orchestrator/Program.cs
+++ b/service-orchestrator/Program.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Text.Json.Serialization;
 using Authentication;
 using Classes;
+using hasheous_server.Controllers.v1_0;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
@@ -11,7 +12,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Versioning;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.OpenApi.Models;
-using hasheous_server.Controllers.v1_0;
 using static Authentication.InterHostApiKey;
 using static Classes.Common;
 
@@ -223,7 +223,7 @@ Classes.ProcessQueue.QueueProcessor.QueueItems = new List<Classes.ProcessQueue.Q
     new Classes.ProcessQueue.QueueProcessor.QueueItem(Classes.ProcessQueue.QueueItemType.TallyVotes, 1440, false),
 
     // metadata rematch
-    new Classes.ProcessQueue.QueueProcessor.QueueItem(Classes.ProcessQueue.QueueItemType.MetadataMatchSearch, 120, false),
+    new Classes.ProcessQueue.QueueProcessor.QueueItem(Classes.ProcessQueue.QueueItemType.MetadataMatchSearch, 1440, false),
 
     // maintenance services
     // daily


### PR DESCRIPTION
Eliminate the limit clause in the DataObject query to enhance data retrieval capabilities. Adjust the metadata match search interval for better processing efficiency.