### PR TITLE
Shorten Redis cache lifespan to 1 day

### DIFF
--- a/hasheous-lib/Classes/ProcessQueue/Tasks/Dumps.cs
+++ b/hasheous-lib/Classes/ProcessQueue/Tasks/Dumps.cs
@@ -55,7 +55,7 @@ namespace Classes.ProcessQueue
             return null;
         }
 
-        private TimeSpan cacheDuration = TimeSpan.FromDays(3);
+        private TimeSpan cacheDuration = TimeSpan.FromDays(1);
 
         private Newtonsoft.Json.JsonSerializerSettings jsonSettings = new Newtonsoft.Json.JsonSerializerSettings
         {

--- a/hasheous-lib/Classes/Redis.cs
+++ b/hasheous-lib/Classes/Redis.cs
@@ -177,6 +177,12 @@ namespace hasheous.Classes
         /// </remarks>
         public async static Task SetCacheItem<T>(string cacheKey, T data, TimeSpan? expiry = null)
         {
+            // if expiry is greater than 24 hours or null, set it to 24 hours to prevent stale data
+            if (expiry == null || expiry > TimeSpan.FromHours(24))
+            {
+                expiry = TimeSpan.FromHours(24);
+            }
+
             if (Config.RedisConfiguration.Enabled)
             {
                 var settings = new Newtonsoft.Json.JsonSerializerSettings

--- a/hasheous/Controllers/V1.0/MetadataProxyController.cs
+++ b/hasheous/Controllers/V1.0/MetadataProxyController.cs
@@ -296,7 +296,7 @@ namespace hasheous_server.Controllers.v1_0
                 // store in cache
                 if (Config.RedisConfiguration.Enabled)
                 {
-                    await RedisConnection.SetCacheItem<Dictionary<string, object>>(cacheKey, returnValueDict, TimeSpan.FromDays(7));
+                    await RedisConnection.SetCacheItem<Dictionary<string, object>>(cacheKey, returnValueDict, TimeSpan.FromDays(1));
                 }
 
                 return Ok(returnValueDict);
@@ -358,7 +358,7 @@ namespace hasheous_server.Controllers.v1_0
                 // store in cache
                 if (Config.RedisConfiguration.Enabled)
                 {
-                    await RedisConnection.SetCacheItem<List<HasheousClient.Models.Metadata.IGDB.Platform>>(cacheKey, results.ToList(), TimeSpan.FromDays(7));
+                    await RedisConnection.SetCacheItem<List<HasheousClient.Models.Metadata.IGDB.Platform>>(cacheKey, results.ToList(), TimeSpan.FromDays(1));
                 }
 
                 return Ok(results);
@@ -391,7 +391,7 @@ namespace hasheous_server.Controllers.v1_0
                 // store in cache
                 if (Config.RedisConfiguration.Enabled)
                 {
-                    await RedisConnection.SetCacheItem<List<HasheousClient.Models.Metadata.IGDB.Platform>>(cacheKey, searchCache, TimeSpan.FromDays(7));
+                    await RedisConnection.SetCacheItem<List<HasheousClient.Models.Metadata.IGDB.Platform>>(cacheKey, searchCache, TimeSpan.FromDays(1));
                 }
 
                 return Ok(searchCache);
@@ -447,7 +447,7 @@ namespace hasheous_server.Controllers.v1_0
                 // store in cache
                 if (Config.RedisConfiguration.Enabled)
                 {
-                    await RedisConnection.SetCacheItem<List<HasheousClient.Models.Metadata.IGDB.Game>>(cacheKey, results.ToList(), TimeSpan.FromDays(7));
+                    await RedisConnection.SetCacheItem<List<HasheousClient.Models.Metadata.IGDB.Game>>(cacheKey, results.ToList(), TimeSpan.FromDays(1));
                 }
 
                 return Ok(results);
@@ -479,7 +479,7 @@ namespace hasheous_server.Controllers.v1_0
                 // store in cache
                 if (Config.RedisConfiguration.Enabled)
                 {
-                    await RedisConnection.SetCacheItem<List<HasheousClient.Models.Metadata.IGDB.Game>>(cacheKey, searchCache, TimeSpan.FromDays(7));
+                    await RedisConnection.SetCacheItem<List<HasheousClient.Models.Metadata.IGDB.Game>>(cacheKey, searchCache, TimeSpan.FromDays(1));
                 }
 
                 return Ok(searchCache);


### PR DESCRIPTION
Reduce the Redis cache lifespan from 7 days to 1 day to prevent stale data. Adjustments ensure that any expiry greater than 24 hours is capped at 24 hours.