### PR TITLE
Update package versions for dependencies

### DIFF
--- a/hasheous-lib/hasheous-lib.csproj
+++ b/hasheous-lib/hasheous-lib.csproj
@@ -15,7 +15,7 @@
     <DocumentationFile>bin\Release\net8.0\hasheous-lib.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="gaseous-signature-parser" Version="2.4.8" />
+    <PackageReference Include="gaseous-signature-parser" Version="2.4.9" />
     <PackageReference Include="gaseous.IGDB" Version="1.0.5" />
     <PackageReference Include="hasheous-client" Version="1.4.6" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.24" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.11.3" />
+    <PackageReference Include="StackExchange.Redis" Version="2.11.8" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="[9.0.6]" />
     <PackageReference Include="MySqlConnector" Version="2.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.24" />


### PR DESCRIPTION
Bump `gaseous-signature-parser` to version 2.4.9 and `StackExchange.Redis` to version 2.11.8 to incorporate the latest features and fixes.