### PR TITLE
Add foreign key constraint for GameId in Signatures_Roms table

### DIFF
--- a/hasheous-lib/Schema/hasheous-1030.sql
+++ b/hasheous-lib/Schema/hasheous-1030.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Signatures_Roms` ADD CONSTRAINT `fk_Signatures_Games` FOREIGN KEY (`GameId`) REFERENCES `Signatures_Games` (`Id`) ON DELETE CASCADE;


### PR DESCRIPTION
Introduce a foreign key constraint for the GameId column in the Signatures_Roms table to ensure referential integrity with the Signatures_Games table.