### PR TITLE
Add foreign key constraint for SignatureId in DataObject_SignatureMap table

### DIFF
--- a/hasheous-lib/Schema/hasheous-1031.sql
+++ b/hasheous-lib/Schema/hasheous-1031.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `DataObject_SignatureMap` CHANGE `SignatureId` `SignatureId` BIGINT NOT NULL;
+
+ALTER TABLE `DataObject_SignatureMap` ADD CONSTRAINT `fk_DO_Signatures_Games` FOREIGN KEY (`SignatureId`) REFERENCES `Signatures_Games` (`Id`) ON DELETE CASCADE;


### PR DESCRIPTION
Introduce a foreign key constraint for the SignatureId column in the DataObject_SignatureMap table to ensure referential integrity with the Signatures_Games table.