### PR TITLE
Enhance DataObjectMetadataSearch with early timeout for interactive sessions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,6 +54,9 @@ Use this to get productive fast. Follow the existing patterns in this repo over 
   - GiantBomb: when `Config.GiantBomb.APIKey` is present a `FetchGiantBombMetadata` job is queued (default 10080 minutes / 7 days) to refresh GiantBomb platform/game/image data.
   - ScreenScraper: `FetchScreenScraperMetadata` is queued every 1440 minutes (24 hours). It reads cached metadata JSON under `Config.LibraryConfiguration.LibraryMetadataDirectory_Screenscraper/games` and imports records through `XML.XMLIngestor.ImportDatRecord(...)`.
   - Queue task refactor: obsolete blocking entries `GetMissingArtwork` and `MetadataMatchSearch` were removed from metadata fetch task `Blocks` lists. Don’t rely on them for future coordination.
+  - Data object metadata guard: `DataObjects.DataObjectMetadataSearch(objectType, id?, ForceSearch)` now uses an atomic file lock under `~/.hasheous-server/Data/Metadata/Hasheous/DataObjectFlags` to prevent duplicate concurrent runs for the same `(objectType, id)` key.
+  - Guard behavior details: lock acquisition uses create-new semantics (`FileMode.CreateNew`) and keeps the lock handle open for the full search duration; lock-file collisions cause immediate skip/return.
+  - Stale lock policy: existing lock files are treated as valid for up to 1 hour; older lock files are deleted and lock acquisition is retried. For `id == null`, the lock key uses `all` (for example: `Game_all_MetadataSearchInProgress.flag`).
 
 - JSON & serialization
   - System.Text.Json and Newtonsoft are both configured: enums-as-strings, nulls ignored, max depth 64, indented output (Newtonsoft).

--- a/hasheous-lib/Classes/DataObjects.cs
+++ b/hasheous-lib/Classes/DataObjects.cs
@@ -1863,23 +1863,23 @@ namespace hasheous_server.Classes
         /// <summary>
         /// Performs a metadata look up on DataObjects with no match metadata
         /// </summary>
-        public async Task DataObjectMetadataSearch(DataObjectType objectType, bool ForceSearch = false)
+        public async Task DataObjectMetadataSearch(DataObjectType objectType, bool ForceSearch = false, bool userInteractiveSession = false)
         {
-            await _DataObjectMetadataSearch(objectType, null, ForceSearch);
+            await _DataObjectMetadataSearch(objectType, null, ForceSearch, userInteractiveSession);
         }
 
         /// <summary>
         /// Performs a metadata look up on the selected DataObject if it has no metadata match
         /// </summary>
         /// <param name="id"></param>
-        public async Task DataObjectMetadataSearch(DataObjectType objectType, long? id, bool ForceSearch = false)
+        public async Task DataObjectMetadataSearch(DataObjectType objectType, long? id, bool ForceSearch = false, bool userInteractiveSession = false)
         {
             switch (objectType)
             {
                 case DataObjectType.Company:
                 case DataObjectType.Platform:
                 case DataObjectType.Game:
-                    await _DataObjectMetadataSearch(objectType, id, ForceSearch);
+                    await _DataObjectMetadataSearch(objectType, id, ForceSearch, userInteractiveSession);
                     break;
 
                 default:
@@ -1908,7 +1908,7 @@ namespace hasheous_server.Classes
             "3DO"
         };
 
-        private async Task _DataObjectMetadataSearch(DataObjectType objectType, long? id, bool ForceSearch)
+        private async Task _DataObjectMetadataSearch(DataObjectType objectType, long? id, bool ForceSearch, bool userInteractiveSession)
         {
             HashSet<MetadataSources> ProcessSources = [
                 MetadataSources.IGDB,
@@ -1936,7 +1936,7 @@ namespace hasheous_server.Classes
                 DataObjectItem? singleDataObject = await GetDataObject(objectType, (long)id);
                 if (singleDataObject != null)
                 {
-                    await _DataObjectMetadataSearch_Apply(singleDataObject, logName, rand, objectType, id, ForceSearch, now, ProcessSources, 1, 1);
+                    await _DataObjectMetadataSearch_Apply(singleDataObject, logName, rand, objectType, id, ForceSearch, now, ProcessSources, 1, 1, userInteractiveSession);
                 }
                 else
                 {
@@ -1983,7 +1983,7 @@ namespace hasheous_server.Classes
                         var item = await GetDataObject(objectType, (long)row["Id"]);
                         if (item != null)
                         {
-                            await _DataObjectMetadataSearch_Apply(item, logName, rand, objectType, id, ForceSearch, now, ProcessSources, processedObjectCount, ids.Rows.Count);
+                            await _DataObjectMetadataSearch_Apply(item, logName, rand, objectType, id, ForceSearch, now, ProcessSources, processedObjectCount, ids.Rows.Count, userInteractiveSession);
                         }
 
                         // sleep every 5 rows for half a second to prevent the system from being overwhelmed
@@ -1998,7 +1998,7 @@ namespace hasheous_server.Classes
             Logging.SendReport(logName, null, null, $"Metadata search complete for {processedObjectCount} {objectType} data objects.");
         }
 
-        private async Task _DataObjectMetadataSearch_Apply(DataObjectItem item, string logName, Random rand, DataObjectType objectType, long? id, bool ForceSearch, DateTime now, HashSet<MetadataSources> ProcessSources, int processedObjectCount, int objectTotalCount)
+        private async Task _DataObjectMetadataSearch_Apply(DataObjectItem item, string logName, Random rand, DataObjectType objectType, long? id, bool ForceSearch, DateTime now, HashSet<MetadataSources> ProcessSources, int processedObjectCount, int objectTotalCount, bool userInteractiveSession)
         {
 
             DataObjectItem? itemPlatform = null;
@@ -2191,8 +2191,38 @@ namespace hasheous_server.Classes
 
                         try
                         {
-                            // perform the search
-                            DataObjects.MatchItem searchResult = await metadataHandler.FindMatchItemAsync(item, SearchCandidates, searchOptions);
+                            DataObjects.MatchItem searchResult;
+                            // if we're running in a userInteractiveSession - that is any session initiated by a user (lookup API, or website) then we'll do a timeout on lookups as they can sometimes be long lasting.
+                            if (userInteractiveSession == true)
+                            {
+                                // perform the search with a 5-second timeout; if it exceeds the limit, the task
+                                // continues in the background and we return a default (NoMatch) result immediately
+                                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                                Task<DataObjects.MatchItem> searchTask = metadataHandler.FindMatchItemAsync(item, SearchCandidates, searchOptions);
+                                Task timeoutTask = Task.Delay(Timeout.Infinite, cts.Token);
+
+                                if (await Task.WhenAny(searchTask, timeoutTask) == searchTask)
+                                {
+                                    searchResult = await searchTask;
+                                }
+                                else
+                                {
+                                    Logging.Log(Logging.LogType.Warning, "Metadata Match", $"{processedObjectCount} / {objectTotalCount} - Metadata search for {item.Name} ({metadataSource}) timed out after 5 seconds; continuing in background.");
+                                    metadata.NextSearch = now.AddDays(defaultNextDay);
+                                    metadataUpdates.Add(metadata);
+                                    // let the background task finish on its own; move on to next source
+                                    _ = searchTask.ContinueWith(t =>
+                                    {
+                                        if (t.IsFaulted)
+                                            Logging.Log(Logging.LogType.Warning, "Metadata Match", $"Background metadata search for {item.Name} ({metadataSource}) faulted.", t.Exception);
+                                    }, TaskScheduler.Default);
+                                    continue;
+                                }
+                            }
+                            else
+                            {
+                                searchResult = await metadataHandler.FindMatchItemAsync(item, SearchCandidates, searchOptions);
+                            }
 
                             // update the metadata item with the search results
                             metadata.Id = searchResult.MetadataId;

--- a/hasheous-lib/Classes/DataObjects.cs
+++ b/hasheous-lib/Classes/DataObjects.cs
@@ -1863,23 +1863,23 @@ namespace hasheous_server.Classes
         /// <summary>
         /// Performs a metadata look up on DataObjects with no match metadata
         /// </summary>
-        public async Task DataObjectMetadataSearch(DataObjectType objectType, bool ForceSearch = false, bool userInteractiveSession = false)
+        public async Task DataObjectMetadataSearch(DataObjectType objectType, bool ForceSearch = false)
         {
-            await _DataObjectMetadataSearch(objectType, null, ForceSearch, userInteractiveSession);
+            await _DataObjectMetadataSearch(objectType, null, ForceSearch);
         }
 
         /// <summary>
         /// Performs a metadata look up on the selected DataObject if it has no metadata match
         /// </summary>
         /// <param name="id"></param>
-        public async Task DataObjectMetadataSearch(DataObjectType objectType, long? id, bool ForceSearch = false, bool userInteractiveSession = false)
+        public async Task DataObjectMetadataSearch(DataObjectType objectType, long? id, bool ForceSearch = false)
         {
             switch (objectType)
             {
                 case DataObjectType.Company:
                 case DataObjectType.Platform:
                 case DataObjectType.Game:
-                    await _DataObjectMetadataSearch(objectType, id, ForceSearch, userInteractiveSession);
+                    await _DataObjectMetadataSearch(objectType, id, ForceSearch);
                     break;
 
                 default:
@@ -1908,7 +1908,7 @@ namespace hasheous_server.Classes
             "3DO"
         };
 
-        private async Task _DataObjectMetadataSearch(DataObjectType objectType, long? id, bool ForceSearch, bool userInteractiveSession)
+        private async Task _DataObjectMetadataSearch(DataObjectType objectType, long? id, bool ForceSearch)
         {
             HashSet<MetadataSources> ProcessSources = [
                 MetadataSources.IGDB,
@@ -1936,7 +1936,7 @@ namespace hasheous_server.Classes
                 DataObjectItem? singleDataObject = await GetDataObject(objectType, (long)id);
                 if (singleDataObject != null)
                 {
-                    await _DataObjectMetadataSearch_Apply(singleDataObject, logName, rand, objectType, id, ForceSearch, now, ProcessSources, 1, 1, userInteractiveSession);
+                    await _DataObjectMetadataSearch_Apply(singleDataObject, logName, rand, objectType, id, ForceSearch, now, ProcessSources, 1, 1);
                 }
                 else
                 {
@@ -1983,7 +1983,7 @@ namespace hasheous_server.Classes
                         var item = await GetDataObject(objectType, (long)row["Id"]);
                         if (item != null)
                         {
-                            await _DataObjectMetadataSearch_Apply(item, logName, rand, objectType, id, ForceSearch, now, ProcessSources, processedObjectCount, ids.Rows.Count, userInteractiveSession);
+                            await _DataObjectMetadataSearch_Apply(item, logName, rand, objectType, id, ForceSearch, now, ProcessSources, processedObjectCount, ids.Rows.Count);
                         }
 
                         // sleep every 5 rows for half a second to prevent the system from being overwhelmed
@@ -1998,7 +1998,7 @@ namespace hasheous_server.Classes
             Logging.SendReport(logName, null, null, $"Metadata search complete for {processedObjectCount} {objectType} data objects.");
         }
 
-        private async Task _DataObjectMetadataSearch_Apply(DataObjectItem item, string logName, Random rand, DataObjectType objectType, long? id, bool ForceSearch, DateTime now, HashSet<MetadataSources> ProcessSources, int processedObjectCount, int objectTotalCount, bool userInteractiveSession)
+        private async Task _DataObjectMetadataSearch_Apply(DataObjectItem item, string logName, Random rand, DataObjectType objectType, long? id, bool ForceSearch, DateTime now, HashSet<MetadataSources> ProcessSources, int processedObjectCount, int objectTotalCount)
         {
 
             DataObjectItem? itemPlatform = null;
@@ -2191,38 +2191,8 @@ namespace hasheous_server.Classes
 
                         try
                         {
-                            DataObjects.MatchItem searchResult;
-                            // if we're running in a userInteractiveSession - that is any session initiated by a user (lookup API, or website) then we'll do a timeout on lookups as they can sometimes be long lasting.
-                            if (userInteractiveSession == true)
-                            {
-                                // perform the search with a 5-second timeout; if it exceeds the limit, the task
-                                // continues in the background and we return a default (NoMatch) result immediately
-                                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-                                Task<DataObjects.MatchItem> searchTask = metadataHandler.FindMatchItemAsync(item, SearchCandidates, searchOptions);
-                                Task timeoutTask = Task.Delay(Timeout.Infinite, cts.Token);
-
-                                if (await Task.WhenAny(searchTask, timeoutTask) == searchTask)
-                                {
-                                    searchResult = await searchTask;
-                                }
-                                else
-                                {
-                                    Logging.Log(Logging.LogType.Warning, "Metadata Match", $"{processedObjectCount} / {objectTotalCount} - Metadata search for {item.Name} ({metadataSource}) timed out after 5 seconds; continuing in background.");
-                                    metadata.NextSearch = now.AddDays(defaultNextDay);
-                                    metadataUpdates.Add(metadata);
-                                    // let the background task finish on its own; move on to next source
-                                    _ = searchTask.ContinueWith(t =>
-                                    {
-                                        if (t.IsFaulted)
-                                            Logging.Log(Logging.LogType.Warning, "Metadata Match", $"Background metadata search for {item.Name} ({metadataSource}) faulted.", t.Exception);
-                                    }, TaskScheduler.Default);
-                                    continue;
-                                }
-                            }
-                            else
-                            {
-                                searchResult = await metadataHandler.FindMatchItemAsync(item, SearchCandidates, searchOptions);
-                            }
+                            // perform the search
+                            DataObjects.MatchItem searchResult = await metadataHandler.FindMatchItemAsync(item, SearchCandidates, searchOptions);
 
                             // update the metadata item with the search results
                             metadata.Id = searchResult.MetadataId;

--- a/hasheous-lib/Classes/DataObjects.cs
+++ b/hasheous-lib/Classes/DataObjects.cs
@@ -1865,7 +1865,7 @@ namespace hasheous_server.Classes
         /// </summary>
         public async Task DataObjectMetadataSearch(DataObjectType objectType, bool ForceSearch = false)
         {
-            await _DataObjectMetadataSearch(objectType, null, ForceSearch);
+            await DataObjectMetadataSearch(objectType, null, ForceSearch);
         }
 
         /// <summary>
@@ -1874,6 +1874,13 @@ namespace hasheous_server.Classes
         /// <param name="id"></param>
         public async Task DataObjectMetadataSearch(DataObjectType objectType, long? id, bool ForceSearch = false)
         {
+            using MetadataSearchFlagLock? metadataSearchFlagLock = TryAcquireMetadataSearchFlagLock(objectType, id);
+            if (metadataSearchFlagLock == null)
+            {
+                return;
+            }
+
+            // begin search
             switch (objectType)
             {
                 case DataObjectType.Company:
@@ -1884,6 +1891,91 @@ namespace hasheous_server.Classes
 
                 default:
                     break;
+            }
+        }
+
+        private MetadataSearchFlagLock? TryAcquireMetadataSearchFlagLock(DataObjectType objectType, long? id)
+        {
+            // set in progress flag path
+            string inUseFlagPath = Path.Combine(Config.LibraryConfiguration.LibraryMetadataDirectory_Hasheous, "DataObjectFlags");
+            if (!Directory.Exists(inUseFlagPath))
+            {
+                Directory.CreateDirectory(inUseFlagPath);
+            }
+
+            string idLabel = id?.ToString() ?? "all";
+            string inUseFlagFile = Path.Combine(inUseFlagPath, $"{objectType}_{idLabel}_MetadataSearchInProgress.flag");
+
+            if (File.Exists(inUseFlagFile))
+            {
+                // flag exists - if it's less than an hour old, abort
+                DateTime flagCreationTime = File.GetCreationTimeUtc(inUseFlagFile);
+                if (flagCreationTime > DateTime.UtcNow.AddHours(-1))
+                {
+                    return null;
+                }
+
+                // flag is old - delete it and proceed
+                try
+                {
+                    File.Delete(inUseFlagFile);
+                }
+                catch (IOException)
+                {
+                    return null;
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    return null;
+                }
+            }
+
+            // atomically create lock file; if this fails, another worker already acquired it
+            try
+            {
+                FileStream lockStream = new FileStream(inUseFlagFile, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+                byte[] lockContents = System.Text.Encoding.UTF8.GetBytes("In Progress");
+                lockStream.Write(lockContents, 0, lockContents.Length);
+                lockStream.Flush(true);
+
+                return new MetadataSearchFlagLock(lockStream, inUseFlagFile);
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return null;
+            }
+        }
+
+        private sealed class MetadataSearchFlagLock : IDisposable
+        {
+            private readonly FileStream _lockStream;
+            private readonly string _flagPath;
+
+            public MetadataSearchFlagLock(FileStream lockStream, string flagPath)
+            {
+                _lockStream = lockStream;
+                _flagPath = flagPath;
+            }
+
+            public void Dispose()
+            {
+                _lockStream.Dispose();
+
+                try
+                {
+                    if (File.Exists(_flagPath))
+                    {
+                        File.Delete(_flagPath);
+                    }
+                }
+                catch
+                {
+                    // no-op: stale lock handling is time-based and can recover
+                }
             }
         }
 

--- a/hasheous-lib/Classes/HashLookup2.cs
+++ b/hasheous-lib/Classes/HashLookup2.cs
@@ -57,6 +57,12 @@ namespace Classes
         [System.Text.Json.Serialization.JsonIgnore]
         public bool ForceSearch { get; set; } = true;
 
+        /// <summary>
+        /// Enum representing the valid fields that can be returned in the HashLookup response. This is used to parse the returnFields parameter and determine which fields to include in the response.
+        /// </summary>
+        /// <remarks>
+        /// The returnFields parameter is a comma-separated list of fields that can be included in the HashLookup response. The valid options are defined in this enum. If returnFields is set to "All", all fields will be included in the response. If returnFields is set to a comma-separated list of specific fields, only those fields will be included in the response. The valid fields are: All, Publisher, Platform, Signatures, Metadata, Attributes.
+        /// </remarks>
         public enum ValidFields
         {
             All,
@@ -67,11 +73,28 @@ namespace Classes
             Attributes
         }
 
+        /// <summary>
+        /// Default constructor for HashLookup. This is required for deserialization, but will not initialize the object properly. Ensure that PerformLookup is called after using this constructor to populate the properties of the object.
+        /// </summary>
+        /// <remarks>
+        /// This constructor is primarily used for deserialization when returning a cached HashLookup result from Redis. In this case, the PerformLookup method will not be called, as the properties of the HashLookup object will already be populated with the cached data. However, if this constructor is used for any other purpose, it is important to call the PerformLookup method after instantiating the object to ensure that the properties are properly populated with the results of the hash lookup operation.
+        /// </remarks>
         public HashLookup()
         {
 
         }
 
+        /// <summary>
+        /// Constructor for HashLookup. Initializes the object with the provided parameters and performs the lookup operation.
+        /// </summary>
+        /// <param name="db">The database connection to use for the lookup operation.</param>
+        /// <param name="model">The HashLookupModel containing the hash values to look up.</param>
+        /// <param name="returnAllSources">If true, will return signatures from all sources. If false, will return only the first signature found. Default is false.</param>
+        /// <param name="returnFields">A comma-separated list of fields to return in the response. If "All", all fields will be returned. Default is "All".</param>
+        /// <param name="returnSources">A list of sources to return. If null, will return all sources. Default is null.</param>
+        /// <param name="forceSearch">If true, will force a search even if a cached result is available. Default is true.</param>
+        /// <exception cref="HashNotFoundException">Thrown if the provided hash is not found in any signature database.</exception>
+        /// <returns>A Task representing the asynchronous operation.</returns>
         public HashLookup(Database db, hasheous_server.Models.HashLookupModel model, bool? returnAllSources = false, string? returnFields = "All", List<gaseous_signature_parser.models.RomSignatureObject.RomSignatureObject.Game.Rom.SignatureSourceType>? returnSources = null, bool? forceSearch = true)
         {
             this.db = db;
@@ -82,7 +105,13 @@ namespace Classes
             this.ForceSearch = forceSearch ?? true;
         }
 
-        public async Task PerformLookup()
+        /// <summary>
+        /// Perform the hash lookup operation. This will populate the properties of the HashLookup object with the results of the lookup.
+        /// </summary>
+        /// <param name="userInteractiveSession">If true, will run with a 5 second timeout for metadata search to ensure a timely response for the user. If false, will run without a timeout to ensure the most complete metadata possible, even if it takes a long time.</param>
+        /// <exception cref="HashNotFoundException">Thrown if the provided hash is not found in any signature database.</exception>
+        /// <returns>A Task representing the asynchronous operation.</returns>
+        public async Task PerformLookup(bool userInteractiveSession = false)
         {
             // parse return fields
             List<ValidFields> validFields = new List<ValidFields>();
@@ -167,7 +196,7 @@ namespace Classes
                             dataObjects.AddSignature(publisher.Id, DataObjects.DataObjectType.Company, discoveredSignature.Game.PublisherId);
 
                             // force metadata search
-                            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Company, publisher.Id, true, true);
+                            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Company, publisher.Id, true);
 
                             // re-get the publisher
                             publisher = await dataObjects.GetDataObject(DataObjects.DataObjectType.Company, publisher.Id);
@@ -219,7 +248,7 @@ namespace Classes
                     dataObjects.AddSignature(platform.Id, DataObjects.DataObjectType.Platform, discoveredSignature.Game.SystemId);
 
                     // force metadata search
-                    await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Platform, platform.Id, true, true);
+                    await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Platform, platform.Id, true);
 
                     // re-get the platform
                     platform = await dataObjects.GetDataObject(DataObjects.DataObjectType.Platform, platform.Id);
@@ -361,7 +390,19 @@ namespace Classes
                     }
 
                     // force metadata search
-                    await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Game, game.Id, true, true);
+                    if (userInteractiveSession)
+                    {
+                        // Run with 5 second timeout for interactive sessions
+                        await Task.WhenAny(
+                            dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Game, game.Id, true),
+                            Task.Delay(TimeSpan.FromSeconds(5))
+                        );
+                    }
+                    else
+                    {
+                        // Run without timeout for background operations
+                        await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Game, game.Id, true);
+                    }
 
                     // re-get the game
                     game = await dataObjects.GetDataObject(DataObjects.DataObjectType.Game, game.Id);

--- a/hasheous-lib/Classes/HashLookup2.cs
+++ b/hasheous-lib/Classes/HashLookup2.cs
@@ -167,7 +167,7 @@ namespace Classes
                             dataObjects.AddSignature(publisher.Id, DataObjects.DataObjectType.Company, discoveredSignature.Game.PublisherId);
 
                             // force metadata search
-                            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Company, publisher.Id, true);
+                            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Company, publisher.Id, true, true);
 
                             // re-get the publisher
                             publisher = await dataObjects.GetDataObject(DataObjects.DataObjectType.Company, publisher.Id);
@@ -219,7 +219,7 @@ namespace Classes
                     dataObjects.AddSignature(platform.Id, DataObjects.DataObjectType.Platform, discoveredSignature.Game.SystemId);
 
                     // force metadata search
-                    await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Platform, platform.Id, true);
+                    await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Platform, platform.Id, true, true);
 
                     // re-get the platform
                     platform = await dataObjects.GetDataObject(DataObjects.DataObjectType.Platform, platform.Id);
@@ -361,7 +361,7 @@ namespace Classes
                     }
 
                     // force metadata search
-                    await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Game, game.Id, true);
+                    await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Game, game.Id, true, true);
 
                     // re-get the game
                     game = await dataObjects.GetDataObject(DataObjects.DataObjectType.Game, game.Id);

--- a/hasheous-lib/Classes/ProcessQueue/Tasks/MetadataMatchSearch.cs
+++ b/hasheous-lib/Classes/ProcessQueue/Tasks/MetadataMatchSearch.cs
@@ -20,11 +20,11 @@ namespace Classes.ProcessQueue
             hasheous_server.Classes.DataObjects dataObjects = new hasheous_server.Classes.DataObjects();
 
             Logging.SendReport(Config.LogName, 1, 3, "Metadata Match Search for Platforms...");
-            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Platform);
+            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Platform, userInteractiveSession: false);
             Logging.SendReport(Config.LogName, 2, 3, "Metadata Match Search for Games...");
-            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Game);
+            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Game, userInteractiveSession: false);
             Logging.SendReport(Config.LogName, 3, 3, "Metadata Match Search for Companies...");
-            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Company);
+            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Company, userInteractiveSession: false);
 
             return null; // Assuming the method returns void, we return null here.
         }

--- a/hasheous-lib/Classes/ProcessQueue/Tasks/MetadataMatchSearch.cs
+++ b/hasheous-lib/Classes/ProcessQueue/Tasks/MetadataMatchSearch.cs
@@ -20,11 +20,11 @@ namespace Classes.ProcessQueue
             hasheous_server.Classes.DataObjects dataObjects = new hasheous_server.Classes.DataObjects();
 
             Logging.SendReport(Config.LogName, 1, 3, "Metadata Match Search for Platforms...");
-            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Platform, userInteractiveSession: false);
+            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Platform);
             Logging.SendReport(Config.LogName, 2, 3, "Metadata Match Search for Games...");
-            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Game, userInteractiveSession: false);
+            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Game);
             Logging.SendReport(Config.LogName, 3, 3, "Metadata Match Search for Companies...");
-            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Company, userInteractiveSession: false);
+            await dataObjects.DataObjectMetadataSearch(DataObjects.DataObjectType.Company);
 
             return null; // Assuming the method returns void, we return null here.
         }

--- a/hasheous/Controllers/V1.0/DataObjectController.cs
+++ b/hasheous/Controllers/V1.0/DataObjectController.cs
@@ -496,7 +496,11 @@ namespace hasheous_server.Controllers.v1_0
 
                 if (forceScan)
                 {
-                    await DataObjects.DataObjectMetadataSearch(ObjectType, Id, true, true);
+                    // Run with 10 second timeout for interactive sessions
+                    await Task.WhenAny(
+                        DataObjects.DataObjectMetadataSearch(ObjectType, Id, true),
+                        Task.Delay(TimeSpan.FromSeconds(10))
+                    );
                 }
 
                 return Ok(DataObjects.GetMetadataMap(ObjectType, Id));

--- a/hasheous/Controllers/V1.0/DataObjectController.cs
+++ b/hasheous/Controllers/V1.0/DataObjectController.cs
@@ -496,7 +496,7 @@ namespace hasheous_server.Controllers.v1_0
 
                 if (forceScan)
                 {
-                    await DataObjects.DataObjectMetadataSearch(ObjectType, Id, true);
+                    await DataObjects.DataObjectMetadataSearch(ObjectType, Id, true, true);
                 }
 
                 return Ok(DataObjects.GetMetadataMap(ObjectType, Id));

--- a/hasheous/Controllers/V1.0/LookupController.cs
+++ b/hasheous/Controllers/V1.0/LookupController.cs
@@ -77,7 +77,7 @@ namespace hasheous_server.Controllers.v1_0
                 }
 
                 HashLookup hashLookup = new HashLookup(new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString), model, returnAllSources, returnFields, returnSourcesList);
-                var lookupTask = hashLookup.PerformLookup();
+                var lookupTask = hashLookup.PerformLookup(true);
                 if (await Task.WhenAny(lookupTask, Task.Delay(TimeSpan.FromSeconds(10))) == lookupTask)
                 {
                     // Completed within timeout


### PR DESCRIPTION
Introduce an early timeout mechanism for the DataObjectMetadataSearch method during user interactive sessions. This change allows searches to complete quickly, improving responsiveness while still allowing background processing for longer tasks. Adjustments made throughout the code ensure that the new timeout behavior is consistently applied.