### PR TITLE
Remove deprecated HashLookupController and its endpoints

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,7 @@ Use this to get productive fast. Follow the existing patterns in this repo over 
 - API versioning & routing
   - Controllers use `[ApiController]`, `[ApiVersion("1.0")]`, `[Route("api/v{version:apiVersion}/[controller]/")]`.
   - Prefer using cache profiles: `"5Minute"` or `"7Days"` configured in `hasheous/Program.cs` (see `LookupController` usage).
+  - Deprecated hash-lookup route note: `HashLookupController` and `POST /api/v1/HashLookup/Lookup` are no longer active. Use `LookupController` endpoints (for example `POST /api/v1/Lookup/ByHash`) for all hash lookup behavior.
   - Data object admin task endpoints are exposed on `DataObjectsController` for moderators/admins:
     - `GET /api/v1/DataObjects/{ObjectType}/{Id}/Tasks` returns all task records for the object.
     - `GET /api/v1/DataObjects/{ObjectType}/{Id}/Tasks/{TaskId}?resetTask=true` returns a single task and optionally resets it.

--- a/hasheous/Controllers/V1.0/HashLookupController.cs
+++ b/hasheous/Controllers/V1.0/HashLookupController.cs
@@ -9,56 +9,56 @@ using static Authentication.ApiKey;
 
 namespace hasheous_server.Controllers.v1_0
 {
-    /// <summary>
-    /// Endpoints used for looking up hash signatures and their metadata id mappings
-    /// </summary>
-    [ApiController]
-    [Route("api/v{version:apiVersion}/[controller]/")]
-    [Obsolete("This controller is deprecated and will be removed in a future version of the API. Please use the new LookupController instead.")]
-    [ApiVersion("1.0")]
-    [IgnoreAntiforgeryToken]
-    [Insight(Insights.InsightSourceType.HashLookupDeprecated)]
-    public class HashLookupController : ControllerBase
-    {
-        /// <summary>
-        /// DEPRECATION Notice - This endpoint was used during development and should not be used anymore. It will be removed at a later date.
-        /// Look up the signature coresponding to the provided MD5 and SHA1 hash - and if available any mapped metadata ids
-        /// </summary>
-        /// <returns>Game and ROM signature from available DATs, and if available mapped metadata ids. 404 if no signature is found.</returns>
-        [MapToApiVersion("1.0")]
-        [HttpPost]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [Route("Lookup")]
-        public async Task<IActionResult> Lookup(HashLookupModel model)
-        {
-            try
-            {
-                // send legacy lookups to new lookup code as well - we'll do this until we're sure no one is using this old endpoint anymore
-                HashLookup hashLookup = new HashLookup(new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString), model);
-                await hashLookup.PerformLookup();
+    // /// <summary>
+    // /// Endpoints used for looking up hash signatures and their metadata id mappings
+    // /// </summary>
+    // [ApiController]
+    // [Route("api/v{version:apiVersion}/[controller]/")]
+    // [Obsolete("This controller is deprecated and will be removed in a future version of the API. Please use the new LookupController instead.")]
+    // [ApiVersion("1.0")]
+    // [IgnoreAntiforgeryToken]
+    // [Insight(Insights.InsightSourceType.HashLookupDeprecated)]
+    // public class HashLookupController : ControllerBase
+    // {
+    //     /// <summary>
+    //     /// DEPRECATION Notice - This endpoint was used during development and should not be used anymore. It will be removed at a later date.
+    //     /// Look up the signature coresponding to the provided MD5 and SHA1 hash - and if available any mapped metadata ids
+    //     /// </summary>
+    //     /// <returns>Game and ROM signature from available DATs, and if available mapped metadata ids. 404 if no signature is found.</returns>
+    //     [MapToApiVersion("1.0")]
+    //     [HttpPost]
+    //     [ProducesResponseType(StatusCodes.Status200OK)]
+    //     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    //     [Route("Lookup")]
+    //     public async Task<IActionResult> Lookup(HashLookupModel model)
+    //     {
+    //         try
+    //         {
+    //             // send legacy lookups to new lookup code as well - we'll do this until we're sure no one is using this old endpoint anymore
+    //             HashLookup hashLookup = new HashLookup(new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString), model);
+    //             await hashLookup.PerformLookup();
 
-                if (hashLookup == null)
-                {
-                    return NotFound();
-                }
-                else
-                {
-                    Dictionary<string, object> returnObject = new Dictionary<string, object>{
-                        { "signature", hashLookup.Signature },
-                        { "metadataIds", new List<string>()}
-                    };
-                    return Ok(returnObject);
-                }
-            }
-            catch (HashLookup.HashNotFoundException hnfEx)
-            {
-                return NotFound("The provided hash was not found in the signature database.");
-            }
-            catch
-            {
-                return NotFound();
-            }
-        }
-    }
+    //             if (hashLookup == null)
+    //             {
+    //                 return NotFound();
+    //             }
+    //             else
+    //             {
+    //                 Dictionary<string, object> returnObject = new Dictionary<string, object>{
+    //                     { "signature", hashLookup.Signature },
+    //                     { "metadataIds", new List<string>()}
+    //                 };
+    //                 return Ok(returnObject);
+    //             }
+    //         }
+    //         catch (HashLookup.HashNotFoundException hnfEx)
+    //         {
+    //             return NotFound("The provided hash was not found in the signature database.");
+    //         }
+    //         catch
+    //         {
+    //             return NotFound();
+    //         }
+    //     }
+    // }
 }


### PR DESCRIPTION
Eliminate the HashLookupController and its associated endpoints, which are no longer in use and have been marked for removal. This change streamlines the API by removing outdated functionality.