### PR TITLE
Allow multiple hashes to be submitted as filters when searching for a game by hash

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,11 +105,24 @@ If something is unclear or missing (e.g., additional services, tests, or new aut
   - See `LookupController.LookupPost`: `Task.WhenAny(..., Task.Delay(TimeSpan.FromSeconds(10)))` and set `Retry-After = 90` on 503 responses.
   - Interactive hash lookup metadata searches use a short `Task.Delay(TimeSpan.FromSeconds(2))` guard to keep UI-driven requests responsive.
 
+- Raw-body POST endpoints and Swagger documentation
+  - `LookupPost` (`POST /api/v1/Lookup/ByHash`) accepts a raw JSON body instead of a bound model parameter. The action reads `Request.Body` directly via `StreamReader` and calls `JsonDocument.Parse(...)` manually.
+  - This avoids ASP.NET Core model binding requiring a named form/query field; the body can be a JSON object `{"crc":"..."}` or a JSON array `[{"crc":"..."},{"md5":"..."}]`. A quoted JSON string containing an object/array is also accepted.
+  - Because there is no bindable parameter, Swagger cannot infer the request body automatically. Use an `IOperationFilter` to inject the `OpenApiRequestBody` manually for such actions. The filter `LookupRequestBodyOperationFilter` in `hasheous-lib/Classes/SwaggerLookupRequestBodyFilter.cs` is the reference implementation; register it with `options.OperationFilter<LookupRequestBodyOperationFilter>()` in `StartupExtensions.cs`.
+  - When adding other raw-body endpoints, follow this same pattern: read body manually in the action and add a dedicated `IOperationFilter` for Swagger documentation.
+
 ## Signature lookup behavior
 - `SignatureManagement.GetRawSignatures(...)` excludes zero-size ROM signature rows by default (`Signatures_Roms.Size > 0`) before hash-condition matching.
 - Keep the non-zero-size filter when extending hash lookup SQL unless a feature explicitly requires zero-byte signatures.
 - `SignatureManagement.BuildGameItem(...)` currently populates both singular and plural dictionary properties for compatibility: `Country` and `Countries`, `Language` and `Languages`.
 - Data object signature listing for games includes `Signatures_Games.Country`; frontend game signature labels/suggestions append country text in `wwwroot/pages/dataobjectdetail.js` and `wwwroot/pages/dataobjectedit.js`.
+
+### Multi-hash lookup (new behavior)
+- `GetRawSignatures(...)` accepts a list of `HashLookupModel` where each element specifies one or more hash fields (CRC/MD5/SHA1/SHA256). Each valid hash field generates a typed token subquery using `UNION ALL`; the outer JOIN then uses `HAVING COUNT(DISTINCT HashToken) = N` to require that **all** tokens are matched by the same `GameId`.
+- This means different hashes in different array elements can be on different ROM rows, as long as they belong to the same game.
+- The outer WHERE clause still retains the full `OR` list of hash conditions so only matching ROM rows are returned (same columns/object mapping as before).
+- `tokenCount` tracks how many valid hash tokens were built; `modelCount` is a separate counter used for parameter naming to avoid `dbDict` key collisions across models.
+- Do not deduplicate tokens by value when extending — each new hash field should add its own uniquely-named parameter (`@sha256{modelCount}`, `@crc{modelCount}`, etc.).
 
 - Correlation & logging
   - Middleware sets `CallContext` values (CorrelationId, CallingProcess, CallingUser); orchestrator also returns `x-correlation-id` header.

--- a/hasheous-cli/hasheous-cli.csproj
+++ b/hasheous-cli/hasheous-cli.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="MySqlConnector" Version="2.5.0" />
+    <PackageReference Include="MySqlConnector" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/hasheous-lib/Classes/HashLookup2.cs
+++ b/hasheous-lib/Classes/HashLookup2.cs
@@ -39,7 +39,7 @@ namespace Classes
 
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
-        public hasheous_server.Models.HashLookupModel model { get; set; }
+        public List<hasheous_server.Models.HashLookupModel> model { get; set; }
 
         [Newtonsoft.Json.JsonIgnore]
         [System.Text.Json.Serialization.JsonIgnore]
@@ -95,7 +95,7 @@ namespace Classes
         /// <param name="forceSearch">If true, will force a search even if a cached result is available. Default is true.</param>
         /// <exception cref="HashNotFoundException">Thrown if the provided hash is not found in any signature database.</exception>
         /// <returns>A Task representing the asynchronous operation.</returns>
-        public HashLookup(Database db, hasheous_server.Models.HashLookupModel model, bool? returnAllSources = false, string? returnFields = "All", List<gaseous_signature_parser.models.RomSignatureObject.RomSignatureObject.Game.Rom.SignatureSourceType>? returnSources = null, bool? forceSearch = true)
+        public HashLookup(Database db, List<hasheous_server.Models.HashLookupModel> model, bool? returnAllSources = false, string? returnFields = "All", List<gaseous_signature_parser.models.RomSignatureObject.RomSignatureObject.Game.Rom.SignatureSourceType>? returnSources = null, bool? forceSearch = true)
         {
             this.db = db;
             this.model = model;
@@ -135,20 +135,39 @@ namespace Classes
             // get the raw signature
             List<Signatures_Games_2> rawSignatures = await signature.GetRawSignatures(model);
 
+            // organise rawSignatures into a dictionary keyed by game id, with the value being a list of signatures for that game
+            Dictionary<string, List<Signatures_Games_2>> signaturesByGameId = new Dictionary<string, List<Signatures_Games_2>>();
+            foreach (Signatures_Games_2 sig in rawSignatures)
+            {
+                if (sig.Game != null)
+                {
+                    if (!signaturesByGameId.ContainsKey(sig.Game.Id))
+                    {
+                        signaturesByGameId.Add(sig.Game.Id, new List<Signatures_Games_2>());
+                    }
+                    signaturesByGameId[sig.Game.Id].Add(sig);
+                }
+            }
+
+            if (signaturesByGameId.Count > 30)
+            {
+                throw new HashNotFoundException("The provided hash returned too many results to process. Please provide a more specific hash or check the input for errors.");
+            }
+
             // narrow down the options
             Signatures_Games_2 discoveredSignature = new Signatures_Games_2();
-            if (rawSignatures.Count == 0)
+            if (signaturesByGameId.Keys.Count == 0)
             {
                 throw new HashNotFoundException("The provided hash was not found in any signature database.");
             }
             else
             {
-                if (rawSignatures.Count == 1)
+                if (signaturesByGameId.Keys.Count == 1)
                 {
                     // only 1 signature found!
-                    discoveredSignature = rawSignatures.ElementAt(0);
+                    discoveredSignature = signaturesByGameId.Values.First().First();
                 }
-                else if (rawSignatures.Count > 1)
+                else if (signaturesByGameId.Keys.Count > 1)
                 {
                     // more than one signature found - find one with highest score
                     foreach (Signatures_Games_2 Sig in rawSignatures)

--- a/hasheous-lib/Classes/SignatureManagement.cs
+++ b/hasheous-lib/Classes/SignatureManagement.cs
@@ -25,20 +25,26 @@ namespace Classes
             }
         }
 
-        public async Task<List<Signatures_Games_2>> GetRawSignatures(HashLookupModel model)
+        /// <summary>
+        /// Gets the raw signature data for a given set of hashes. This is used by the lookup endpoints to get the signature data that is then filtered and returned to the user.
+        /// </summary>
+        /// <param name="models">A list of hash lookup models containing the hashes to search for.</param>
+        /// <returns>A list of raw signature data matching the provided hashes.</returns>
+        /// <exception cref="Exception"></exception>
+        public async Task<List<Signatures_Games_2>> GetRawSignatures(List<HashLookupModel> models)
         {
             // check the archive observations for the provided hashes
-            HashLookupModel? observedHashes = await GetObservedArchiveHashesAsync(model);
+            HashLookupModel? observedHashes = await GetObservedArchiveHashesAsync(models.FirstOrDefault());
             if (observedHashes != null)
             {
                 // if the archive is observed, return the hashes from the observations
-                model.MD5 = observedHashes.MD5;
-                model.SHA1 = observedHashes.SHA1;
-                model.SHA256 = observedHashes.SHA256;
-                model.CRC = observedHashes.CRC;
+                models.FirstOrDefault().MD5 = observedHashes.MD5;
+                models.FirstOrDefault().SHA1 = observedHashes.SHA1;
+                models.FirstOrDefault().SHA256 = observedHashes.SHA256;
+                models.FirstOrDefault().CRC = observedHashes.CRC;
             }
 
-            string cacheKey = RedisConnection.GenerateKey("Signature", model);
+            string cacheKey = RedisConnection.GenerateKey("Signature", models);
             // check if the query is cached
             if (Config.RedisConfiguration.Enabled)
             {
@@ -52,45 +58,61 @@ namespace Classes
 
             Dictionary<string, object> dbDict = new Dictionary<string, object>();
             List<string> whereClauses = new List<string>();
+            List<string> tokenSelectClauses = new List<string>();
+            int modelCount = 0;
+            int tokenCount = 0;
+            foreach (var model in models)
+            {
+                if (model.SHA256 != null)
+                {
+                    if (model.SHA256.Length == 64)
+                    {
+                        whereClauses.Add("Signatures_Roms.SHA256 = @sha256" + modelCount);
+                        tokenSelectClauses.Add("SELECT Signatures_Roms.GameId, 'token" + tokenCount + "' AS HashToken FROM Signatures_Roms WHERE Signatures_Roms.Size > 0 AND Signatures_Roms.SHA256 = @sha256" + modelCount);
+                        dbDict.Add("sha256" + modelCount, model.SHA256);
+                        tokenCount++;
+                    }
+                }
+                if (model.SHA1 != null)
+                {
+                    if (model.SHA1.Length == 40)
+                    {
+                        whereClauses.Add("Signatures_Roms.SHA1 = @sha1" + modelCount);
+                        tokenSelectClauses.Add("SELECT Signatures_Roms.GameId, 'token" + tokenCount + "' AS HashToken FROM Signatures_Roms WHERE Signatures_Roms.Size > 0 AND Signatures_Roms.SHA1 = @sha1" + modelCount);
+                        dbDict.Add("sha1" + modelCount, model.SHA1);
+                        tokenCount++;
+                    }
+                }
+                if (model.MD5 != null)
+                {
+                    if (model.MD5.Length == 32)
+                    {
+                        whereClauses.Add("Signatures_Roms.MD5 = @md5" + modelCount);
+                        tokenSelectClauses.Add("SELECT Signatures_Roms.GameId, 'token" + tokenCount + "' AS HashToken FROM Signatures_Roms WHERE Signatures_Roms.Size > 0 AND Signatures_Roms.MD5 = @md5" + modelCount);
+                        dbDict.Add("md5" + modelCount, model.MD5);
+                        tokenCount++;
+                    }
+                }
+                if (model.CRC != null)
+                {
+                    if (model.CRC.Length == 8)
+                    {
+                        whereClauses.Add("Signatures_Roms.CRC = @crc" + modelCount);
+                        tokenSelectClauses.Add("SELECT Signatures_Roms.GameId, 'token" + tokenCount + "' AS HashToken FROM Signatures_Roms WHERE Signatures_Roms.Size > 0 AND Signatures_Roms.CRC = @crc" + modelCount);
+                        dbDict.Add("crc" + modelCount, model.CRC);
+                        tokenCount++;
+                    }
+                }
+                modelCount++;
+            }
 
-            if (model.SHA256 != null)
-            {
-                if (model.SHA256.Length == 64)
-                {
-                    whereClauses.Add("Signatures_Roms.SHA256 = @sha256");
-                    dbDict.Add("sha256", model.SHA256);
-                }
-            }
-            if (model.SHA1 != null)
-            {
-                if (model.SHA1.Length == 40)
-                {
-                    whereClauses.Add("Signatures_Roms.SHA1 = @sha1");
-                    dbDict.Add("sha1", model.SHA1);
-                }
-            }
-            if (model.MD5 != null)
-            {
-                if (model.MD5.Length == 32)
-                {
-                    whereClauses.Add("Signatures_Roms.MD5 = @md5");
-                    dbDict.Add("md5", model.MD5);
-                }
-            }
-            if (model.CRC != null)
-            {
-                if (model.CRC.Length == 8)
-                {
-                    whereClauses.Add("Signatures_Roms.CRC = @crc");
-                    dbDict.Add("crc", model.CRC);
-                }
-            }
-
-            if (whereClauses.Count > 0)
+            if (whereClauses.Count > 0 && tokenSelectClauses.Count > 0)
             {
                 // lookup the provided hashes
                 Database db = new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString);
-                string sql = "SELECT view_Signatures_Games.*, Signatures_Roms.Id AS romid, Signatures_Roms.Name AS romname, Signatures_Roms.Size, Signatures_Roms.CRC, Signatures_Roms.MD5, Signatures_Roms.SHA1, Signatures_Roms.SHA256, Signatures_Roms.Status, Signatures_Roms.DevelopmentStatus, Signatures_Roms.Attributes, Signatures_Roms.RomType, Signatures_Roms.RomTypeMedia, Signatures_Roms.MediaLabel, Signatures_Roms.MetadataSource, Signatures_Roms.Countries, Signatures_Roms.Languages FROM Signatures_Roms INNER JOIN view_Signatures_Games ON Signatures_Roms.GameId = view_Signatures_Games.Id WHERE Signatures_Roms.Size > 0 AND " + string.Join(" OR ", whereClauses);
+                dbDict.Add("requiredHashTokenCount", tokenSelectClauses.Count);
+
+                string sql = "SELECT view_Signatures_Games.*, Signatures_Roms.Id AS romid, Signatures_Roms.Name AS romname, Signatures_Roms.Size, Signatures_Roms.CRC, Signatures_Roms.MD5, Signatures_Roms.SHA1, Signatures_Roms.SHA256, Signatures_Roms.Status, Signatures_Roms.DevelopmentStatus, Signatures_Roms.Attributes, Signatures_Roms.RomType, Signatures_Roms.RomTypeMedia, Signatures_Roms.MediaLabel, Signatures_Roms.MetadataSource, Signatures_Roms.Countries, Signatures_Roms.Languages FROM Signatures_Roms INNER JOIN view_Signatures_Games ON Signatures_Roms.GameId = view_Signatures_Games.Id INNER JOIN (SELECT TokenMatches.GameId FROM (" + string.Join(" UNION ALL ", tokenSelectClauses) + ") AS TokenMatches GROUP BY TokenMatches.GameId HAVING COUNT(DISTINCT TokenMatches.HashToken) = @requiredHashTokenCount) AS QualifiedGames ON QualifiedGames.GameId = Signatures_Roms.GameId WHERE Signatures_Roms.Size > 0 AND (" + string.Join(" OR ", whereClauses) + ")";
 
                 DataTable sigDb = await db.ExecuteCMDAsync(sql, dbDict);
 

--- a/hasheous-lib/Classes/Submissions.cs
+++ b/hasheous-lib/Classes/Submissions.cs
@@ -35,12 +35,15 @@ namespace hasheous_server.Classes
             else
             {
                 // if DataObjectId is not provided, look it up based on the hashes
-                HashLookup hashLookup = new HashLookup(db, new Models.HashLookupModel
+                HashLookup hashLookup = new HashLookup(db, new List<Models.HashLookupModel>
                 {
-                    MD5 = model.MD5,
-                    SHA1 = model.SHA1,
-                    SHA256 = model.SHA256,
-                    CRC = model.CRC
+                    new Models.HashLookupModel
+                    {
+                        MD5 = model.MD5,
+                        SHA1 = model.SHA1,
+                        SHA256 = model.SHA256,
+                        CRC = model.CRC
+                    }
                 });
                 await hashLookup.PerformLookup();
 
@@ -401,12 +404,15 @@ namespace hasheous_server.Classes
             Database db = new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString);
 
             // check if the content hash already exists
-            HashLookup hashLookup = new HashLookup(db, new Models.HashLookupModel
+            HashLookup hashLookup = new HashLookup(db, new List<Models.HashLookupModel>
             {
-                MD5 = model.Content.MD5,
-                SHA1 = model.Content.SHA1,
-                SHA256 = model.Content.SHA256,
-                CRC = model.Content.CRC
+                new Models.HashLookupModel
+                {
+                    MD5 = model.Content.MD5,
+                    SHA1 = model.Content.SHA1,
+                    SHA256 = model.Content.SHA256,
+                    CRC = model.Content.CRC
+                }
             });
             await hashLookup.PerformLookup();
 

--- a/hasheous-lib/Classes/SwaggerLookupRequestBodyFilter.cs
+++ b/hasheous-lib/Classes/SwaggerLookupRequestBodyFilter.cs
@@ -1,0 +1,78 @@
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+public class LookupRequestBodyOperationFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        if (context.ApiDescription.ActionDescriptor is not ControllerActionDescriptor controllerActionDescriptor)
+        {
+            return;
+        }
+
+        if (controllerActionDescriptor.ControllerName != "Lookup" || controllerActionDescriptor.ActionName != "LookupPost")
+        {
+            return;
+        }
+
+        operation.RequestBody = new OpenApiRequestBody
+        {
+            Required = true,
+            Description = "Raw JSON body containing either one hash object or an array of hash objects. Each object may contain crc, md5, sha1, and/or sha256 fields.",
+            Content =
+            {
+                ["application/json"] = new OpenApiMediaType
+                {
+                    Schema = new OpenApiSchema
+                    {
+                        OneOf = new List<OpenApiSchema>
+                        {
+                            new OpenApiSchema
+                            {
+                                Type = "object",
+                                AdditionalProperties = new OpenApiSchema
+                                {
+                                    Type = "string",
+                                    Nullable = true
+                                },
+                                Example = new OpenApiObject
+                                {
+                                    ["crc"] = new OpenApiString("12ec7f82"),
+                                    ["md5"] = new OpenApiString("5d7550788a4d1b47ad81fbbbf5c615a9"),
+                                    ["sha1"] = new OpenApiString("274ed5c2ea2ddc855f67d4c4e61c9d9b7eb68403"),
+                                    ["sha256"] = new OpenApiString("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+                                }
+                            },
+                            new OpenApiSchema
+                            {
+                                Type = "array",
+                                Items = new OpenApiSchema
+                                {
+                                    Type = "object",
+                                    AdditionalProperties = new OpenApiSchema
+                                    {
+                                        Type = "string",
+                                        Nullable = true
+                                    }
+                                },
+                                Example = new OpenApiArray
+                                {
+                                    new OpenApiObject
+                                    {
+                                        ["crc"] = new OpenApiString("12ec7f82")
+                                    },
+                                    new OpenApiObject
+                                    {
+                                        ["md5"] = new OpenApiString("5d7550788a4d1b47ad81fbbbf5c615a9")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+}

--- a/hasheous-lib/hasheous-lib.csproj
+++ b/hasheous-lib/hasheous-lib.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="craftersmine.SteamGridDB.Net" Version="1.1.7" />
     <PackageReference Include="gaseous-signature-parser" Version="2.7.0" />
     <PackageReference Include="gaseous.IGDB" Version="1.0.5" />
-    <PackageReference Include="hasheous-client" Version="1.4.10" />
+    <PackageReference Include="hasheous-client" Version="1.5.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.27" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.27" />
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.13.17" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="[9.0.6]" />
-    <PackageReference Include="MySqlConnector" Version="2.5.0" />
+    <PackageReference Include="MySqlConnector" Version="2.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.27" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.27" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />

--- a/hasheous/Controllers/V1.0/LookupController.cs
+++ b/hasheous/Controllers/V1.0/LookupController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Classes;
 using Classes.Insights;
 using hasheous_server.Classes;
@@ -20,9 +21,6 @@ namespace hasheous_server.Controllers.v1_0
         /// <summary>
         /// Look up the signature coresponding to the provided MD5 and SHA1 hash - and if available, any mapped metadata ids
         /// </summary>
-        /// <param name="model" required="true">
-        /// A JSON element with MD5 or SHA1 key value pairs representing the hashes of the ROM being queried.
-        /// </param>
         /// <param name="returnAllSources" required="false" default="false" example="true">
         /// If true, all sources will be returned. If false, only the first source will be returned.
         /// </param>
@@ -51,9 +49,11 @@ namespace hasheous_server.Controllers.v1_0
         [HttpPost]
         [ProducesResponseType(typeof(HashLookup), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [ResponseCache(CacheProfileName = "5Minute")]
         [Route("ByHash")]
-        public async Task<IActionResult> LookupPost(HashLookupModel model, bool? returnAllSources = false, string? returnFields = "All", string? returnSources = null)
+        public async Task<IActionResult> LookupPost(bool? returnAllSources = false, string? returnFields = "All", string? returnSources = null)
         {
             try
             {
@@ -76,7 +76,77 @@ namespace hasheous_server.Controllers.v1_0
                     }
                 }
 
-                HashLookup hashLookup = new HashLookup(new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString), model, returnAllSources, returnFields, returnSourcesList);
+                // [{"crc": "12ec7f82"}, {"crc": "836a0187"}]
+
+                List<hasheous_server.Models.HashLookupModel> modelList = new List<hasheous_server.Models.HashLookupModel>();
+                var jsonOptions = new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                };
+
+                using var reader = new StreamReader(Request.Body);
+                string rawRequestBody = await reader.ReadToEndAsync();
+                if (string.IsNullOrWhiteSpace(rawRequestBody))
+                {
+                    return BadRequest("Invalid model payload. Provide a JSON object or array containing hash fields.");
+                }
+
+                JsonElement normalizedModel;
+                try
+                {
+                    using JsonDocument parsedBody = JsonDocument.Parse(rawRequestBody);
+                    normalizedModel = parsedBody.RootElement.Clone();
+                }
+                catch (JsonException)
+                {
+                    return BadRequest("Invalid model payload. Body must be valid JSON.");
+                }
+
+                // Some clients send JSON text as a quoted string (for example, "[{...}]").
+                // Parse the inner JSON so both raw and string-encoded JSON are accepted.
+                if (normalizedModel.ValueKind == JsonValueKind.String)
+                {
+                    string? rawModelString = normalizedModel.GetString();
+                    if (string.IsNullOrWhiteSpace(rawModelString))
+                    {
+                        return BadRequest("Invalid model payload. Provide a JSON object or array containing hash fields.");
+                    }
+
+                    try
+                    {
+                        using JsonDocument parsedStringModel = JsonDocument.Parse(rawModelString);
+                        normalizedModel = parsedStringModel.RootElement.Clone();
+                    }
+                    catch (JsonException)
+                    {
+                        return BadRequest("Invalid model payload. String body must contain valid JSON object or array text.");
+                    }
+                }
+
+                // accept raw JSON object or array in request body and deserialize manually
+                if (normalizedModel.ValueKind == JsonValueKind.Array)
+                {
+                    modelList = JsonSerializer.Deserialize<List<hasheous_server.Models.HashLookupModel>>(normalizedModel.GetRawText(), jsonOptions) ?? new List<hasheous_server.Models.HashLookupModel>();
+                }
+                else if (normalizedModel.ValueKind == JsonValueKind.Object)
+                {
+                    var deserializedModel = JsonSerializer.Deserialize<hasheous_server.Models.HashLookupModel>(normalizedModel.GetRawText(), jsonOptions);
+                    if (deserializedModel != null)
+                    {
+                        modelList.Add(deserializedModel);
+                    }
+                }
+                else
+                {
+                    return BadRequest("Invalid model payload. Provide a JSON object or array containing hash fields.");
+                }
+
+                if (modelList.Count == 0 || modelList.All(x => string.IsNullOrWhiteSpace(x.MD5) && string.IsNullOrWhiteSpace(x.SHA1) && string.IsNullOrWhiteSpace(x.SHA256) && string.IsNullOrWhiteSpace(x.CRC)))
+                {
+                    return BadRequest("Invalid model payload. Provide at least one hash field (MD5, SHA1, SHA256, CRC).");
+                }
+
+                HashLookup hashLookup = new HashLookup(new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString), modelList, returnAllSources, returnFields, returnSourcesList);
                 var lookupTask = hashLookup.PerformLookup(true);
                 if (await Task.WhenAny(lookupTask, Task.Delay(TimeSpan.FromSeconds(10))) == lookupTask)
                 {
@@ -101,11 +171,11 @@ namespace hasheous_server.Controllers.v1_0
             }
             catch (HashLookup.HashNotFoundException hnfEx)
             {
-                return NotFound("The provided hash was not found in the signature database.");
+                return NotFound(hnfEx.Message);
             }
             catch (Exception ex)
             {
-                Logging.Log(Logging.LogType.Warning, "Hash Lookup", "An error occurred while looking up a hash: " + model.MD5 + " " + model.SHA1 + ": " + ex.Message, ex);
+                Logging.Log(Logging.LogType.Warning, "Hash Lookup", "An error occurred while looking up a hash: " + ex.Message, ex);
                 return StatusCode(StatusCodes.Status500InternalServerError, "An error occurred while looking up the hash. Please try again later.");
             }
         }
@@ -129,12 +199,15 @@ namespace hasheous_server.Controllers.v1_0
         {
             try
             {
-                HashLookup hashLookup = new HashLookup(new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString), new HashLookupModel
+                HashLookup hashLookup = new HashLookup(new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString), new List<hasheous_server.Models.HashLookupModel>
                 {
-                    MD5 = md5,
-                    SHA1 = sha1,
-                    SHA256 = sha256,
-                    CRC = crc
+                    new hasheous_server.Models.HashLookupModel
+                    {
+                        MD5 = md5,
+                        SHA1 = sha1,
+                        SHA256 = sha256,
+                        CRC = crc
+                    }
                 });
                 await hashLookup.PerformLookup();
 

--- a/hasheous/StartupExtensions.cs
+++ b/hasheous/StartupExtensions.cs
@@ -163,6 +163,7 @@ public static class StartupExtensions
                 Scheme = "TaskWorkerApiKeyScheme"
             });
             options.OperationFilter<AuthorizationOperationFilter>();
+            options.OperationFilter<LookupRequestBodyOperationFilter>();
             options.DocumentFilter<IGDBMetadataDocumentFilter>();
             options.SwaggerDoc("v1", new OpenApiInfo
             {


### PR DESCRIPTION
- Updated GetRawSignatures method to accept a list of HashLookupModel objects instead of a single instance, allowing for batch processing of hash lookups.
- Enhanced SQL query construction to dynamically handle multiple hash conditions and ensure efficient database lookups.
- Modified LookupController to accept raw JSON input for hash lookups, supporting both single and array formats for improved API flexibility.
- Added Swagger documentation for the new request body format in LookupController.
- Introduced a new operation filter for Swagger to document the expected request body structure for hash lookups.
- Updated submissions handling to align with the new list-based hash lookup model.