### PR TITLE
Prevent zero-byte hash lookups in LookupController

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -125,11 +125,13 @@ If something is unclear or missing (e.g., additional services, tests, or new aut
 - Raw-body POST endpoints and Swagger documentation
   - `LookupPost` (`POST /api/v1/Lookup/ByHash`) accepts a raw JSON body instead of a bound model parameter. The action reads `Request.Body` directly via `StreamReader` and calls `JsonDocument.Parse(...)` manually.
   - This avoids ASP.NET Core model binding requiring a named form/query field; the body can be a JSON object `{"crc":"..."}` or a JSON array `[{"crc":"..."},{"md5":"..."}]`. A quoted JSON string containing an object/array is also accepted.
+  - `LookupController` validates request payloads manually and rejects explicit zero-byte hashes with `400 Bad Request` before the database lookup runs.
   - Because there is no bindable parameter, Swagger cannot infer the request body automatically. Use an `IOperationFilter` to inject the `OpenApiRequestBody` manually for such actions. The filter `LookupRequestBodyOperationFilter` in `hasheous-lib/Classes/SwaggerLookupRequestBodyFilter.cs` is the reference implementation; register it with `options.OperationFilter<LookupRequestBodyOperationFilter>()` in `StartupExtensions.cs`.
   - When adding other raw-body endpoints, follow this same pattern: read body manually in the action and add a dedicated `IOperationFilter` for Swagger documentation.
 
 ## Signature lookup behavior
 - `SignatureManagement.GetRawSignatures(...)` excludes zero-size ROM signature rows by default (`Signatures_Roms.Size > 0`) before hash-condition matching.
+- `LookupController` now rejects explicit zero-byte hashes early for both raw-body `POST /api/v1/Lookup/ByHash` and direct `GET /api/v1/Lookup/ByHash/{hash}` routes, returning `400 Bad Request` rather than querying the signature database.
 - Keep the non-zero-size filter when extending hash lookup SQL unless a feature explicitly requires zero-byte signatures.
 - `SignatureManagement.BuildGameItem(...)` currently populates both singular and plural dictionary properties for compatibility: `Country` and `Countries`, `Language` and `Languages`.
 - Data object signature listing for games includes `Signatures_Games.Country`; frontend game signature labels/suggestions append country text in `wwwroot/pages/dataobjectdetail.js` and `wwwroot/pages/dataobjectedit.js`.

--- a/hasheous-lib/Classes/SignatureManagement.cs
+++ b/hasheous-lib/Classes/SignatureManagement.cs
@@ -112,7 +112,7 @@ namespace Classes
                 // lookup the provided hashes
                 Database db = new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString);
 
-                string sql = "SELECT view_Signatures_Games.*, Signatures_Roms.Id AS romid, Signatures_Roms.Name AS romname, Signatures_Roms.Size, Signatures_Roms.CRC, Signatures_Roms.MD5, Signatures_Roms.SHA1, Signatures_Roms.SHA256, Signatures_Roms.Status, Signatures_Roms.DevelopmentStatus, Signatures_Roms.Attributes, Signatures_Roms.RomType, Signatures_Roms.RomTypeMedia, Signatures_Roms.MediaLabel, Signatures_Roms.MetadataSource, Signatures_Roms.Countries, Signatures_Roms.Languages FROM Signatures_Roms INNER JOIN view_Signatures_Games ON Signatures_Roms.GameId = view_Signatures_Games.Id WHERE Signatures_Roms.Size > 0 AND (" + string.Join(" OR ", whereClauses) + ") AND " + string.Join(" AND ", modelGameMatchClauses);
+                string sql = "SELECT view_Signatures_Games.*, Signatures_Roms.Id AS romid, Signatures_Roms.Name AS romname, Signatures_Roms.Size, Signatures_Roms.CRC, Signatures_Roms.MD5, Signatures_Roms.SHA1, Signatures_Roms.SHA256, Signatures_Roms.Status, Signatures_Roms.DevelopmentStatus, Signatures_Roms.Attributes, Signatures_Roms.RomType, Signatures_Roms.RomTypeMedia, Signatures_Roms.MediaLabel, Signatures_Roms.MetadataSource, Signatures_Roms.Countries, Signatures_Roms.Languages FROM Signatures_Roms INNER JOIN view_Signatures_Games ON Signatures_Roms.GameId = view_Signatures_Games.Id WHERE (" + string.Join(" OR ", whereClauses) + ") AND " + string.Join(" AND ", modelGameMatchClauses);
 
                 DataTable sigDb = await db.ExecuteCMDAsync(sql, dbDict);
 

--- a/hasheous/Controllers/V1.0/LookupController.cs
+++ b/hasheous/Controllers/V1.0/LookupController.cs
@@ -18,6 +18,11 @@ namespace hasheous_server.Controllers.v1_0
     [Insight(Insights.InsightSourceType.HashLookup)]
     public class LookupController : ControllerBase
     {
+        private static string zeroByteMD5 = "d41d8cd98f00b204e9800998ecf8427e";
+        private static string zeroByteSHA1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+        private static string zeroByteSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        private static string zeroByteCRC = "00000000";
+
         /// <summary>
         /// Look up the signature coresponding to the provided MD5 and SHA1 hash - and if available, any mapped metadata ids
         /// </summary>
@@ -146,6 +151,12 @@ namespace hasheous_server.Controllers.v1_0
                     return BadRequest("Invalid model payload. Provide at least one hash field (MD5, SHA1, SHA256, CRC).");
                 }
 
+                // fail on obvious zero byte hashes to avoid unnecessary lookups
+                if (modelList.Count == 1 && modelList.Any(x => x.MD5 == zeroByteMD5 || x.SHA1 == zeroByteSHA1 || x.SHA256 == zeroByteSHA256 || x.CRC == zeroByteCRC))
+                {
+                    return BadRequest("Invalid model payload. Zero-byte hashes are not allowed.");
+                }
+
                 HashLookup hashLookup = new HashLookup(new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString), modelList, returnAllSources, returnFields, returnSourcesList);
                 var lookupTask = hashLookup.PerformLookup(true);
                 if (await Task.WhenAny(lookupTask, Task.Delay(TimeSpan.FromSeconds(10))) == lookupTask)
@@ -197,6 +208,12 @@ namespace hasheous_server.Controllers.v1_0
         [Route("ByHash/crc/{crc}")]
         public async Task<IActionResult> LookupGet(string? md5, string? sha1, string? sha256, string? crc)
         {
+            // fail on obvious zero byte hashes to avoid unnecessary lookups
+            if (md5 == zeroByteMD5 || sha1 == zeroByteSHA1 || sha256 == zeroByteSHA256 || crc == zeroByteCRC)
+            {
+                return BadRequest("Invalid hash provided. Zero-byte hashes are not allowed.");
+            }
+
             try
             {
                 HashLookup hashLookup = new HashLookup(new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString), new List<hasheous_server.Models.HashLookupModel>


### PR DESCRIPTION
Introduce constants for zero-byte hashes and implement checks to prevent lookups for these invalid hashes in the LookupController. This enhances the robustness of hash lookups by avoiding unnecessary database queries.