### PR TITLE
Add StorageFallbackResolver for local and S3 stream resolution

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,9 @@ Use this to get productive fast. Follow the existing patterns in this repo over 
   - MCP is hosted on the public `hasheous` web API at `POST /api/v1/Mcp` (controller: `hasheous/Controllers/V1.0/McpController.cs`; shared processor: `hasheous-lib/Classes/Mcp/McpRequestProcessor.cs`).
   - MCP discovery is published at `GET /.well-known/mcp.json` (controller: `hasheous/Controllers/WellKnownController.cs`) and should point clients to the hosted MCP endpoint.
   - Redis (Valkey) provides caching if enabled (`Classes/RedisConnection`), otherwise an in-memory cache is used.
+  - Metadata file caching now supports optional S3-compatible object storage fallback (including MinIO) via shared helpers in `hasheous-lib/Classes/S3StorageTools.cs` and `hasheous-lib/Classes/StorageFallbackResolver.cs`.
+  - Metadata proxy image and bundle routes use local-disk first, then S3 fallback, and fail open: if S3 is unavailable they fall back to existing provider fetch/build behavior without surfacing S3 errors to clients.
+  - S3 uploads for newly downloaded/built files are scheduled on response completion (`HttpContext.Response.OnCompleted`) so client download latency is not blocked by object-store upload time.
   - Separation: the orchestration server exists to separate background tasks from the frontend web server. The frontend web server only services user requests; the orchestrator schedules and runs internal/background work (`QueueProcessor.QueueItems` in `service-orchestrator/Program.cs`). Note the orchestrator has no public endpoints, and should only be called by trusted web servers using the inter-host API key.
 
 - Run & debug (local)
@@ -29,8 +32,12 @@ Use this to get productive fast. Follow the existing patterns in this repo over 
 
 - Configuration
   - File: `~/.hasheous-server/config.json` (auto-updated on startup by `Config.UpdateConfig()`). Env vars (used by Docker): `dbhost`, `dbuser`, `dbpass`, `igdbclientid`, `igdbclientsecret`, `redisenabled`, `redishost`, `redisport`, `reportingserverurl`, etc.
+  - S3 config (`Config.S3StorageConfiguration`): `Enabled`, `Region`, `ServiceUrl`, `AccessKey`, `SecretKey`, `SessionToken`, `ForcePathStyle`, `DefaultBucket`.
+  - S3 env vars: `s3enabled`, `s3region`, `s3serviceurl`, `s3accesskey`, `s3secretkey`, `s3sessiontoken`, `s3forcepathstyle`.
+  - For MinIO and similar S3-compatible endpoints, use host-only `ServiceUrl` (for example `https://s3.mrgtech.net`) and typically set `ForcePathStyle = true`.
+  - S3 fallback is effectively disabled when either `Enabled` is false or bucket/key inputs are missing.
   - Temporary metadata bundle workspace is configured via `Config.LibraryConfiguration.LibraryTemporaryBundlesDirectory` (defaults to `Path.Combine(Path.GetTempPath(), "Bundles")`).
-  - Development mode disables client API key requirement (`Config.RequireClientAPIKey = false`) and enables developer exception page.
+  - Development mode disables client API key requirement by setting `Config.RequireClientAPIKey = false` in `hasheous/StartupExtensions.cs` (`ConfigureDevelopmentModeAsync`) and enables developer exception page.
   - GiantBomb: set `gbapikey` env var (or update config.json) to enable GiantBomb metadata ingestion & proxy; optional `BaseURL` override (defaults to `https://www.giantbomb.com/`).
   - SteamGridDB: set `sgdbapikey` env var (or update config.json -> `SteamGridDBConfiguration.APIKey`) to enable SteamGridDB metadata matching.
 
@@ -45,6 +52,7 @@ Use this to get productive fast. Follow the existing patterns in this repo over 
   - Swagger is enabled with custom schema IDs and API key security definitions.
   - MCP endpoint route: `POST /api/v1/Mcp` (JSON-RPC over HTTP). Keep MCP internet-facing endpoints in `hasheous` (not `service-orchestrator`).
   - Discovery route: `GET /.well-known/mcp.json` for client/server discovery metadata.
+  - Metadata proxy file routes (`IGDB/Image`, `TheGamesDB/Images`, `GiantBomb/a/uploads`, and `Bundles/{MetadataSourceName}/{GameID}.bundle`) may return either physical-file or stream-backed file results depending on cache source; do not assume `PhysicalFileResult` only when consuming these actions internally.
   - MCP lookups are intentionally public: the hosted MCP controller uses `[AllowAnonymous]` rather than API key auth.
 
 - Auth & security

--- a/hasheous-lib/Classes/Config.cs
+++ b/hasheous-lib/Classes/Config.cs
@@ -158,6 +158,17 @@ namespace Classes
         }
 
         /// <summary>
+        /// Gets the S3 storage configuration settings.
+        /// </summary>
+        public static ConfigFile.S3Storage S3StorageConfiguration
+        {
+            get
+            {
+                return _config.S3StorageConfiguration;
+            }
+        }
+
+        /// <summary>
         /// Gets the social authentication configuration settings.
         /// </summary>
         public static ConfigFile.SocialAuth SocialAuthConfiguration
@@ -598,6 +609,11 @@ namespace Classes
             /// Gets or sets the SteamGridDB configuration settings.
             /// </summary>
             public SteamGridDB SteamGridDBConfiguration = new SteamGridDB();
+
+            /// <summary>
+            /// Gets or sets the S3 storage configuration settings.
+            /// </summary>
+            public S3Storage S3StorageConfiguration = new S3Storage();
 
             /// <summary>
             /// Gets or sets the social authentication configuration settings.
@@ -1456,6 +1472,164 @@ namespace Classes
                 /// Gets or sets the API key used for authenticating requests to the SteamGridDB service.
                 /// </summary>
                 public string APIKey = _DefaultAPIKey;
+            }
+
+            /// <summary>
+            /// Represents the S3 storage configuration settings.
+            /// </summary>
+            public class S3Storage
+            {
+                private static bool _Enabled
+                {
+                    get
+                    {
+                        string? envVar = Environment.GetEnvironmentVariable("s3enabled");
+                        if (!String.IsNullOrEmpty(envVar))
+                        {
+                            return bool.Parse(envVar);
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                private static string _Region
+                {
+                    get
+                    {
+                        string? envVar = Environment.GetEnvironmentVariable("s3region");
+                        if (!String.IsNullOrEmpty(envVar))
+                        {
+                            return envVar;
+                        }
+                        else
+                        {
+                            return "us-east-1";
+                        }
+                    }
+                }
+
+                private static string _ServiceUrl
+                {
+                    get
+                    {
+                        string? envVar = Environment.GetEnvironmentVariable("s3serviceurl");
+                        if (!String.IsNullOrEmpty(envVar))
+                        {
+                            return envVar;
+                        }
+                        else
+                        {
+                            return "";
+                        }
+                    }
+                }
+
+                private static string _AccessKey
+                {
+                    get
+                    {
+                        string? envVar = Environment.GetEnvironmentVariable("s3accesskey");
+                        if (!String.IsNullOrEmpty(envVar))
+                        {
+                            return envVar;
+                        }
+                        else
+                        {
+                            return "";
+                        }
+                    }
+                }
+
+                private static string _SecretKey
+                {
+                    get
+                    {
+                        string? envVar = Environment.GetEnvironmentVariable("s3secretkey");
+                        if (!String.IsNullOrEmpty(envVar))
+                        {
+                            return envVar;
+                        }
+                        else
+                        {
+                            return "";
+                        }
+                    }
+                }
+
+                private static string _SessionToken
+                {
+                    get
+                    {
+                        string? envVar = Environment.GetEnvironmentVariable("s3sessiontoken");
+                        if (!String.IsNullOrEmpty(envVar))
+                        {
+                            return envVar;
+                        }
+                        else
+                        {
+                            return "";
+                        }
+                    }
+                }
+
+                private static bool _ForcePathStyle
+                {
+                    get
+                    {
+                        string? envVar = Environment.GetEnvironmentVariable("s3forcepathstyle");
+                        if (!String.IsNullOrEmpty(envVar))
+                        {
+                            return bool.Parse(envVar);
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                /// <summary>
+                /// Gets or sets a value indicating whether S3 storage support is enabled.
+                /// </summary>
+                public bool Enabled = _Enabled;
+
+                /// <summary>
+                /// Gets or sets the AWS region used when connecting to S3.
+                /// </summary>
+                public string Region = _Region;
+
+                /// <summary>
+                /// Gets or sets an optional S3-compatible service URL.
+                /// </summary>
+                public string ServiceUrl = _ServiceUrl;
+
+                /// <summary>
+                /// Gets or sets the S3 access key.
+                /// </summary>
+                public string AccessKey = _AccessKey;
+
+                /// <summary>
+                /// Gets or sets the S3 secret key.
+                /// </summary>
+                public string SecretKey = _SecretKey;
+
+                /// <summary>
+                /// Gets or sets an optional S3 session token.
+                /// </summary>
+                public string SessionToken = _SessionToken;
+
+                /// <summary>
+                /// Gets or sets a value indicating whether path-style addressing should be used.
+                /// </summary>
+                public bool ForcePathStyle = _ForcePathStyle;
+
+                /// <summary>
+                /// Gets or sets the default bucket used by callers that do not provide one.
+                /// </summary>
+                public string DefaultBucket = "";
             }
 
             /// <summary>

--- a/hasheous-lib/Classes/S3StorageTools.cs
+++ b/hasheous-lib/Classes/S3StorageTools.cs
@@ -1,0 +1,174 @@
+using System.Net;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+
+namespace Classes
+{
+    /// <summary>
+    /// Low-level tools for checking, uploading, and reading objects from S3-compatible storage.
+    /// </summary>
+    public class S3StorageTools
+    {
+        private readonly IAmazonS3 _client;
+
+        public S3StorageTools(IAmazonS3? client = null)
+        {
+            _client = client ?? BuildClientFromConfig();
+        }
+
+        public static IAmazonS3 BuildClientFromConfig()
+        {
+            var s3Config = Config.S3StorageConfiguration;
+
+            AmazonS3Config clientConfig = new AmazonS3Config
+            {
+                RegionEndpoint = RegionEndpoint.GetBySystemName(s3Config.Region),
+                ForcePathStyle = s3Config.ForcePathStyle
+            };
+
+            if (!string.IsNullOrWhiteSpace(s3Config.ServiceUrl))
+            {
+                clientConfig.ServiceURL = s3Config.ServiceUrl;
+            }
+
+            AWSCredentials credentials;
+            if (string.IsNullOrWhiteSpace(s3Config.AccessKey) || string.IsNullOrWhiteSpace(s3Config.SecretKey))
+            {
+                credentials = FallbackCredentialsFactory.GetCredentials();
+            }
+            else if (string.IsNullOrWhiteSpace(s3Config.SessionToken))
+            {
+                credentials = new BasicAWSCredentials(s3Config.AccessKey, s3Config.SecretKey);
+            }
+            else
+            {
+                credentials = new SessionAWSCredentials(s3Config.AccessKey, s3Config.SecretKey, s3Config.SessionToken);
+            }
+
+            return new AmazonS3Client(credentials, clientConfig);
+        }
+
+        /// <summary>
+        /// Fast existence check using object metadata lookup.
+        /// </summary>
+        public async Task<bool> ContentExistsAsync(string bucketName, string fileName, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                await _client.GetObjectMetadataAsync(new GetObjectMetadataRequest
+                {
+                    BucketName = bucketName,
+                    Key = fileName
+                }, cancellationToken);
+
+                return true;
+            }
+            catch (AmazonS3Exception ex) when (
+                ex.StatusCode == HttpStatusCode.NotFound ||
+                ex.ErrorCode == "NotFound" ||
+                ex.ErrorCode == "NoSuchKey" ||
+                ex.ErrorCode == "NoSuchBucket")
+            {
+                return false;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Uploads a local file to the target bucket and key.
+        /// Returns false when overwrite is disabled and the key already exists.
+        /// </summary>
+        public async Task<bool> UploadFileAsync(string bucketName, string fileName, string localFilePath, bool overwrite = false, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(localFilePath) || !File.Exists(localFilePath))
+            {
+                throw new FileNotFoundException("Local file not found for S3 upload.", localFilePath);
+            }
+
+            if (!overwrite && await ContentExistsAsync(bucketName, fileName, cancellationToken))
+            {
+                return false;
+            }
+
+            try
+            {
+                PutObjectResponse response = await _client.PutObjectAsync(new PutObjectRequest
+                {
+                    BucketName = bucketName,
+                    Key = fileName,
+                    FilePath = localFilePath
+                }, cancellationToken);
+
+                return response.HttpStatusCode == HttpStatusCode.OK || response.HttpStatusCode == HttpStatusCode.NoContent;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Opens an object from S3 as a readable stream.
+        /// Returns null if the object or bucket does not exist.
+        /// </summary>
+        public async Task<S3ObjectStream?> OpenReadStreamAsync(string bucketName, string fileName, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                GetObjectResponse response = await _client.GetObjectAsync(new GetObjectRequest
+                {
+                    BucketName = bucketName,
+                    Key = fileName
+                }, cancellationToken);
+
+                return new S3ObjectStream(response);
+            }
+            catch (AmazonS3Exception ex) when (
+                ex.StatusCode == HttpStatusCode.NotFound ||
+                ex.ErrorCode == "NotFound" ||
+                ex.ErrorCode == "NoSuchKey" ||
+                ex.ErrorCode == "NoSuchBucket")
+            {
+                return null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Wraps a streamed S3 object response and owns disposal of the underlying response stream.
+    /// </summary>
+    public sealed class S3ObjectStream : IDisposable, IAsyncDisposable
+    {
+        private readonly GetObjectResponse _response;
+
+        public S3ObjectStream(GetObjectResponse response)
+        {
+            _response = response;
+        }
+
+        public Stream Stream => _response.ResponseStream;
+        public string? ContentType => _response.Headers.ContentType;
+        public long ContentLength => _response.ContentLength;
+        public string? ETag => _response.ETag;
+
+        public void Dispose()
+        {
+            _response.Dispose();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _response.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/hasheous-lib/Classes/StorageFallbackResolver.cs
+++ b/hasheous-lib/Classes/StorageFallbackResolver.cs
@@ -1,0 +1,212 @@
+namespace Classes
+{
+    public enum ResolvedStreamSource
+    {
+        Local,
+        S3
+    }
+
+    /// <summary>
+    /// Stream wrapper returned by the local/S3 fallback resolver.
+    /// </summary>
+    public sealed class ResolvedContentStream : IDisposable, IAsyncDisposable
+    {
+        private readonly Stream? _localStream;
+        private readonly S3ObjectStream? _s3ObjectStream;
+
+        private ResolvedContentStream(Stream localStream, long contentLength)
+        {
+            Source = ResolvedStreamSource.Local;
+            _localStream = localStream;
+            Stream = localStream;
+            ContentLength = contentLength;
+        }
+
+        private ResolvedContentStream(S3ObjectStream s3ObjectStream)
+        {
+            Source = ResolvedStreamSource.S3;
+            _s3ObjectStream = s3ObjectStream;
+            Stream = s3ObjectStream.Stream;
+            ContentLength = s3ObjectStream.ContentLength;
+            ContentType = s3ObjectStream.ContentType;
+            ETag = s3ObjectStream.ETag;
+        }
+
+        public ResolvedStreamSource Source { get; }
+        public Stream Stream { get; }
+        public long? ContentLength { get; }
+        public string? ContentType { get; }
+        public string? ETag { get; }
+
+        public static ResolvedContentStream FromLocal(Stream stream, long contentLength)
+        {
+            return new ResolvedContentStream(stream, contentLength);
+        }
+
+        public static ResolvedContentStream FromS3(S3ObjectStream s3ObjectStream)
+        {
+            return new ResolvedContentStream(s3ObjectStream);
+        }
+
+        public void Dispose()
+        {
+            _localStream?.Dispose();
+            _s3ObjectStream?.Dispose();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_localStream != null)
+            {
+                await _localStream.DisposeAsync();
+            }
+
+            if (_s3ObjectStream != null)
+            {
+                await _s3ObjectStream.DisposeAsync();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolves file streams using local disk first, then S3 fallback.
+    /// </summary>
+    public class StorageFallbackResolver
+    {
+        private readonly S3StorageTools _s3StorageTools;
+
+        public StorageFallbackResolver(S3StorageTools? s3StorageTools = null)
+        {
+            _s3StorageTools = s3StorageTools ?? new S3StorageTools();
+        }
+
+        /// <summary>
+        /// Resolves a file stream by checking local disk first, then S3.
+        /// The fallback resolver requires both bucketName and fileName for the S3 lookup.
+        /// Returns null when neither local nor S3 has the requested file.
+        /// </summary>
+        public async Task<ResolvedContentStream?> ResolveReadStreamAsync(string localFilePath, string bucketName, string fileName, CancellationToken cancellationToken = default)
+        {
+            if (!string.IsNullOrWhiteSpace(localFilePath) && File.Exists(localFilePath))
+            {
+                FileInfo fileInfo = new FileInfo(localFilePath);
+                if (fileInfo.Length > 0)
+                {
+                    FileStream fileStream = new FileStream(localFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan);
+                    return ResolvedContentStream.FromLocal(fileStream, fileInfo.Length);
+                }
+
+                // Remove invalid zero-length cache entries and continue fallback resolution.
+                File.Delete(localFilePath);
+            }
+
+            if (!IsS3FallbackEnabled(bucketName, fileName))
+            {
+                return null;
+            }
+
+            S3ObjectStream? s3Stream = await _s3StorageTools.OpenReadStreamAsync(bucketName, fileName, cancellationToken);
+            if (s3Stream != null)
+            {
+                // Read-through cache: local-miss + S3-hit stores locally for future requests.
+                if (!string.IsNullOrWhiteSpace(localFilePath))
+                {
+                    bool storedLocally = await TryStoreS3StreamLocallyAsync(s3Stream, localFilePath, cancellationToken);
+                    if (storedLocally && File.Exists(localFilePath))
+                    {
+                        FileInfo cachedFileInfo = new FileInfo(localFilePath);
+                        if (cachedFileInfo.Length > 0)
+                        {
+                            FileStream localStream = new FileStream(localFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan);
+                            return ResolvedContentStream.FromLocal(localStream, cachedFileInfo.Length);
+                        }
+                    }
+
+                    // If local cache write failed, the original S3 stream may have been consumed.
+                    // Re-open from S3 so the caller still receives a readable stream.
+                    await s3Stream.DisposeAsync();
+                    s3Stream = await _s3StorageTools.OpenReadStreamAsync(bucketName, fileName, cancellationToken);
+                    if (s3Stream == null)
+                    {
+                        return null;
+                    }
+                }
+
+                return ResolvedContentStream.FromS3(s3Stream);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Uploads a local file to S3.
+        /// Returns false when local file is missing, S3 is disabled, or overwrite is false and the object already exists.
+        /// </summary>
+        public async Task<bool> UploadLocalFileToS3Async(string localFilePath, string bucketName, string fileName, bool overwrite = false, CancellationToken cancellationToken = default)
+        {
+            if (!Config.S3StorageConfiguration.Enabled)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(bucketName) || string.IsNullOrWhiteSpace(fileName))
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(localFilePath) || !File.Exists(localFilePath))
+            {
+                return false;
+            }
+
+            return await _s3StorageTools.UploadFileAsync(bucketName, fileName, localFilePath, overwrite, cancellationToken);
+        }
+
+        private static bool IsS3FallbackEnabled(string bucketName, string fileName)
+        {
+            if (!Config.S3StorageConfiguration.Enabled)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(bucketName) || string.IsNullOrWhiteSpace(fileName))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static async Task<bool> TryStoreS3StreamLocallyAsync(S3ObjectStream s3Stream, string localFilePath, CancellationToken cancellationToken)
+        {
+            try
+            {
+                string? localDirectory = Path.GetDirectoryName(localFilePath);
+                if (!string.IsNullOrWhiteSpace(localDirectory) && !Directory.Exists(localDirectory))
+                {
+                    Directory.CreateDirectory(localDirectory);
+                }
+
+                string tempPath = localFilePath + ".tmp." + Guid.NewGuid().ToString("N");
+
+                await using (FileStream localWriteStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan))
+                {
+                    await s3Stream.Stream.CopyToAsync(localWriteStream, 81920, cancellationToken);
+                }
+
+                if (File.Exists(localFilePath))
+                {
+                    File.Delete(localFilePath);
+                }
+
+                File.Move(tempPath, localFilePath);
+                await s3Stream.DisposeAsync();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/hasheous-lib/hasheous-lib.csproj
+++ b/hasheous-lib/hasheous-lib.csproj
@@ -15,6 +15,7 @@
     <DocumentationFile>bin\Release\net10.0\hasheous-lib.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="4.0.4" />
     <PackageReference Include="craftersmine.SteamGridDB.Net" Version="1.1.7" />
     <PackageReference Include="gaseous-signature-parser" Version="2.7.0" />
     <PackageReference Include="gaseous.IGDB" Version="1.0.5" />

--- a/hasheous/Controllers/V1.0/MetadataProxyController.cs
+++ b/hasheous/Controllers/V1.0/MetadataProxyController.cs
@@ -488,6 +488,36 @@ namespace hasheous_server.Controllers.v1_0
 
         private static HttpClient client = new HttpClient();
 
+        private async Task<IActionResult?> TryServeFromLocalOrS3Async(string localFilePath, string s3Key, string fallbackContentType)
+        {
+            StorageFallbackResolver resolver = new StorageFallbackResolver();
+            string bucketName = Config.S3StorageConfiguration.DefaultBucket;
+
+            ResolvedContentStream? resolved = await resolver.ResolveReadStreamAsync(localFilePath, bucketName, s3Key);
+            if (resolved == null)
+            {
+                return null;
+            }
+
+            HttpContext.Response.RegisterForDispose(resolved);
+
+            string contentType = string.IsNullOrWhiteSpace(resolved.ContentType) ? fallbackContentType : resolved.ContentType;
+            return File(resolved.Stream, contentType);
+        }
+
+        private void ScheduleLocalCacheUploadToS3(string localFilePath, string s3Key)
+        {
+            if (!Config.S3StorageConfiguration.Enabled)
+            {
+                return;
+            }
+
+            StorageFallbackResolver resolver = new StorageFallbackResolver();
+            string bucketName = Config.S3StorageConfiguration.DefaultBucket;
+
+            HttpContext.Response.OnCompleted(() => resolver.UploadLocalFileToS3Async(localFilePath, bucketName, s3Key, overwrite: false));
+        }
+
         /// <summary>
         /// Get image from IGDB
         /// </summary>
@@ -513,6 +543,7 @@ namespace hasheous_server.Controllers.v1_0
 
             string imageDirectory = Path.Combine(Config.LibraryConfiguration.LibraryMetadataDirectory_IGDB, "Images");
             string imagePath = Path.Combine(imageDirectory, ImageId + ".jpg");
+            string s3Key = $"IGDB/Images/{ImageId}.jpg";
 
             // create directory if it doesn't exist
             if (!System.IO.Directory.Exists(imageDirectory))
@@ -520,79 +551,70 @@ namespace hasheous_server.Controllers.v1_0
                 System.IO.Directory.CreateDirectory(imageDirectory);
             }
 
-            // check if image exists
-            if (System.IO.File.Exists(imagePath))
+            IActionResult? cachedResult = await TryServeFromLocalOrS3Async(imagePath, s3Key, "image/jpeg");
+            if (cachedResult != null)
             {
-                // check the file is non-zero length
-                FileInfo fileInfo = new FileInfo(imagePath);
-                if (fileInfo.Length == 0)
-                {
-                    System.IO.File.Delete(imagePath);
-                    return NotFound();
-                }
-
-                return PhysicalFile(imagePath, "image/jpeg");
+                return cachedResult;
             }
-            else
+
+            // get image from IGDB
+            string url = String.Format("https://images.igdb.com/igdb/image/upload/t_{0}/{1}.jpg", "original", ImageId);
+
+            // download image from url
+            try
             {
-                // get image from IGDB
-                string url = String.Format("https://images.igdb.com/igdb/image/upload/t_{0}/{1}.jpg", "original", ImageId);
-
-                // download image from url
-                try
+                using (HttpResponseMessage response = client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).Result)
                 {
-                    using (HttpResponseMessage response = client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).Result)
+                    response.EnsureSuccessStatusCode();
+
+                    using (Stream contentStream = await response.Content.ReadAsStreamAsync(), fileStream = new FileStream(imagePath, FileMode.Create, FileAccess.Write, FileShare.None, 8192, true))
                     {
-                        response.EnsureSuccessStatusCode();
+                        var totalRead = 0L;
+                        var totalReads = 0L;
+                        var buffer = new byte[8192];
+                        var isMoreToRead = true;
 
-                        using (Stream contentStream = await response.Content.ReadAsStreamAsync(), fileStream = new FileStream(imagePath, FileMode.Create, FileAccess.Write, FileShare.None, 8192, true))
+                        do
                         {
-                            var totalRead = 0L;
-                            var totalReads = 0L;
-                            var buffer = new byte[8192];
-                            var isMoreToRead = true;
-
-                            do
+                            var read = await contentStream.ReadAsync(buffer, 0, buffer.Length);
+                            if (read == 0)
                             {
-                                var read = await contentStream.ReadAsync(buffer, 0, buffer.Length);
-                                if (read == 0)
-                                {
-                                    isMoreToRead = false;
-                                }
-                                else
-                                {
-                                    await fileStream.WriteAsync(buffer, 0, read);
+                                isMoreToRead = false;
+                            }
+                            else
+                            {
+                                await fileStream.WriteAsync(buffer, 0, read);
 
-                                    totalRead += read;
-                                    totalReads += 1;
+                                totalRead += read;
+                                totalReads += 1;
 
-                                    if (totalReads % 2000 == 0)
-                                    {
-                                        Console.WriteLine(string.Format("total bytes downloaded so far: {0:n0}", totalRead));
-                                    }
+                                if (totalReads % 2000 == 0)
+                                {
+                                    Console.WriteLine(string.Format("total bytes downloaded so far: {0:n0}", totalRead));
                                 }
                             }
-                            while (isMoreToRead);
                         }
+                        while (isMoreToRead);
                     }
-
-                    if (System.IO.File.Exists(imagePath))
-                    {
-                        // check the file is non-zero length
-                        FileInfo fileInfo = new FileInfo(imagePath);
-                        if (fileInfo.Length == 0)
-                        {
-                            System.IO.File.Delete(imagePath);
-                            return NotFound();
-                        }
-                    }
-
-                    return PhysicalFile(imagePath, "image/jpeg");
                 }
-                catch
+
+                if (System.IO.File.Exists(imagePath))
                 {
-                    return NotFound();
+                    // check the file is non-zero length
+                    FileInfo fileInfo = new FileInfo(imagePath);
+                    if (fileInfo.Length == 0)
+                    {
+                        System.IO.File.Delete(imagePath);
+                        return NotFound();
+                    }
                 }
+
+                ScheduleLocalCacheUploadToS3(imagePath, s3Key);
+                return PhysicalFile(imagePath, "image/jpeg");
+            }
+            catch
+            {
+                return NotFound();
             }
         }
 
@@ -628,6 +650,7 @@ namespace hasheous_server.Controllers.v1_0
             }
             string imageFile = Path.Combine(Config.LibraryConfiguration.LibraryMetadataDirectory_TheGamesDb, "Images", ImageSize.ToString(), FileName);
             string imagePath = Path.GetDirectoryName(imageFile);
+            string s3Key = $"TheGamesDB/Images/{ImageSize}/{FileName}";
 
             // create directory if it doesn't exist
             if (!Directory.Exists(imagePath))
@@ -635,9 +658,26 @@ namespace hasheous_server.Controllers.v1_0
                 Directory.CreateDirectory(imagePath);
             }
 
-            // check if image exists
-            if (System.IO.File.Exists(imageFile))
+            IActionResult? cachedResult = await TryServeFromLocalOrS3Async(imageFile, s3Key, "image/jpeg");
+            if (cachedResult != null)
             {
+                return cachedResult;
+            }
+
+            // download image from url
+            try
+            {
+                Uri theGamesDBUri = new Uri("https://cdn.thegamesdb.net/images/" + ImageSize.ToString() + "/" + FileName);
+
+                DownloadManager downloadManager = new DownloadManager();
+                var result = downloadManager.DownloadFile(theGamesDBUri.ToString(), imageFile);
+
+                // wait until result is completed
+                while (result.IsCompleted == false)
+                {
+                    Thread.Sleep(1000);
+                }
+
                 // check the file is non-zero length
                 FileInfo fileInfo = new FileInfo(imageFile);
                 if (fileInfo.Length == 0)
@@ -646,38 +686,12 @@ namespace hasheous_server.Controllers.v1_0
                     return NotFound();
                 }
 
+                ScheduleLocalCacheUploadToS3(imageFile, s3Key);
                 return PhysicalFile(imageFile, "image/jpeg");
             }
-            else
+            catch
             {
-                // download image from url
-                try
-                {
-                    Uri theGamesDBUri = new Uri("https://cdn.thegamesdb.net/images/" + ImageSize.ToString() + "/" + FileName);
-
-                    DownloadManager downloadManager = new DownloadManager();
-                    var result = downloadManager.DownloadFile(theGamesDBUri.ToString(), imageFile);
-
-                    // wait until result is completed
-                    while (result.IsCompleted == false)
-                    {
-                        Thread.Sleep(1000);
-                    }
-
-                    // check the file is non-zero length
-                    FileInfo fileInfo = new FileInfo(imageFile);
-                    if (fileInfo.Length == 0)
-                    {
-                        System.IO.File.Delete(imageFile);
-                        return NotFound();
-                    }
-
-                    return PhysicalFile(imageFile, "image/jpeg");
-                }
-                catch
-                {
-                    return NotFound();
-                }
+                return NotFound();
             }
         }
 
@@ -1226,7 +1240,7 @@ namespace hasheous_server.Controllers.v1_0
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Route("GiantBomb/a/uploads/{*GiantBombImagePath}")]
         [ResponseCache(CacheProfileName = "7Days")]
-        public IActionResult GetGiantBombImage(string GiantBombImagePath)
+        public async Task<IActionResult> GetGiantBombImage(string GiantBombImagePath)
         {
             GiantBombImagePath = System.Uri.UnescapeDataString(GiantBombImagePath);
             if (GiantBombImagePath.Contains("..") || GiantBombImagePath.Contains("\\"))
@@ -1239,6 +1253,7 @@ namespace hasheous_server.Controllers.v1_0
             }
             string imageFile = Path.Combine(Config.LibraryConfiguration.LibraryMetadataDirectory_GiantBomb, "Images", GiantBombImagePath);
             string imagePath = Path.GetDirectoryName(imageFile);
+            string s3Key = $"GiantBomb/Images/{GiantBombImagePath}";
 
             // create directory if it doesn't exist
             if (!Directory.Exists(imagePath))
@@ -1246,9 +1261,26 @@ namespace hasheous_server.Controllers.v1_0
                 Directory.CreateDirectory(imagePath);
             }
 
-            // check if image exists
-            if (System.IO.File.Exists(imageFile))
+            IActionResult? cachedResult = await TryServeFromLocalOrS3Async(imageFile, s3Key, "image/jpeg");
+            if (cachedResult != null)
             {
+                return cachedResult;
+            }
+
+            // download image from url
+            try
+            {
+                Uri giantBombUri = new Uri("https://www.giantbomb.com/a/uploads/" + GiantBombImagePath);
+
+                DownloadManager downloadManager = new DownloadManager();
+                var result = downloadManager.DownloadFile(giantBombUri.ToString(), imageFile);
+
+                // wait until result is completed
+                while (result.IsCompleted == false)
+                {
+                    Thread.Sleep(1000);
+                }
+
                 // check the file is non-zero length
                 FileInfo fileInfo = new FileInfo(imageFile);
                 if (fileInfo.Length == 0)
@@ -1257,38 +1289,12 @@ namespace hasheous_server.Controllers.v1_0
                     return NotFound();
                 }
 
+                ScheduleLocalCacheUploadToS3(imageFile, s3Key);
                 return PhysicalFile(imageFile, "image/jpeg");
             }
-            else
+            catch
             {
-                // download image from url
-                try
-                {
-                    Uri giantBombUri = new Uri("https://www.giantbomb.com/a/uploads/" + GiantBombImagePath);
-
-                    DownloadManager downloadManager = new DownloadManager();
-                    var result = downloadManager.DownloadFile(giantBombUri.ToString(), imageFile);
-
-                    // wait until result is completed
-                    while (result.IsCompleted == false)
-                    {
-                        Thread.Sleep(1000);
-                    }
-
-                    // check the file is non-zero length
-                    FileInfo fileInfo = new FileInfo(imageFile);
-                    if (fileInfo.Length == 0)
-                    {
-                        System.IO.File.Delete(imageFile);
-                        return NotFound();
-                    }
-
-                    return PhysicalFile(imageFile, "image/jpeg");
-                }
-                catch
-                {
-                    return NotFound();
-                }
+                return NotFound();
             }
         }
         #endregion GiantBomb
@@ -1342,6 +1348,7 @@ namespace hasheous_server.Controllers.v1_0
             string fileName = $"{MetadataSourceName}_{GameID}.bundle";
             FileInfo? fileInfo;
             string bundleFilePath = Path.Combine(Config.LibraryConfiguration.LibraryMetadataBundlesDirectory, fileName);
+            string s3Key = $"Bundles/{fileName}";
             bool buildNewBundle = true;
             if (System.IO.File.Exists(bundleFilePath))
             {
@@ -1349,8 +1356,23 @@ namespace hasheous_server.Controllers.v1_0
                 fileInfo = new FileInfo(bundleFilePath);
                 if ((DateTime.Now - fileInfo.LastWriteTime).TotalDays <= Config.MetadataConfiguration.MetadataBundle_MaxAgeInDays)
                 {
-                    // return the existing bundle
-                    buildNewBundle = false;
+                    IActionResult? cachedResult = await TryServeFromLocalOrS3Async(bundleFilePath, s3Key, "application/octet-stream");
+                    if (cachedResult != null)
+                    {
+                        return cachedResult;
+                    }
+
+                    // Rebuild if the existing bundle cannot be served.
+                    buildNewBundle = true;
+                }
+            }
+
+            if (buildNewBundle == true && !System.IO.File.Exists(bundleFilePath))
+            {
+                IActionResult? cachedResult = await TryServeFromLocalOrS3Async(bundleFilePath, s3Key, "application/octet-stream");
+                if (cachedResult != null)
+                {
+                    return cachedResult;
                 }
             }
 
@@ -1440,10 +1462,9 @@ namespace hasheous_server.Controllers.v1_0
                                             if (item.Key == "image_id")
                                             {
                                                 string imageID = item.Value.ToString() ?? "";
-                                                PhysicalFileResult? imageFileData = (PhysicalFileResult?)await GetImage(imageID);
-                                                if (imageFileData != null)
+                                                if (await GetImage(imageID) is FileResult imageFileData)
                                                 {
-                                                    await _AddFileToBundle(tempWorkingDir, imageProperty, imageFileData);
+                                                    await _AddFileToBundle(tempWorkingDir, imageProperty, imageFileData, imageID + ".jpg");
                                                 }
                                             }
                                         }
@@ -1457,10 +1478,9 @@ namespace hasheous_server.Controllers.v1_0
                                             if (imageObj != null && imageObj.ContainsKey("image_id"))
                                             {
                                                 string imageID = imageObj["image_id"].ToString() ?? "";
-                                                PhysicalFileResult? imageFileData = (PhysicalFileResult?)await GetImage(imageID);
-                                                if (imageFileData != null)
+                                                if (await GetImage(imageID) is FileResult imageFileData)
                                                 {
-                                                    await _AddFileToBundle(tempWorkingDir, imageProperty, imageFileData);
+                                                    await _AddFileToBundle(tempWorkingDir, imageProperty, imageFileData, imageID + ".jpg");
                                                 }
                                             }
                                         }
@@ -1507,10 +1527,9 @@ namespace hasheous_server.Controllers.v1_0
                                 foreach (var image in imageObj)
                                 {
                                     string imagePath = image.filename ?? "";
-                                    PhysicalFileResult? imageFileData = (PhysicalFileResult?)await GetTheGamesDBImage(MetadataQuery.imageSize.original, imagePath);
-                                    if (imageFileData != null)
+                                    if (await GetTheGamesDBImage(MetadataQuery.imageSize.original, imagePath) is FileResult imageFileData)
                                     {
-                                        await _AddFileToBundle(tempWorkingDir, image.type, imageFileData);
+                                        await _AddFileToBundle(tempWorkingDir, image.type, imageFileData, Path.GetFileName(imagePath));
                                     }
                                 }
                             }
@@ -1526,6 +1545,8 @@ namespace hasheous_server.Controllers.v1_0
                 }
 
                 ZipFile.CreateFromDirectory(tempWorkingDir, bundleFilePath, CompressionLevel.Fastest, false);
+
+                ScheduleLocalCacheUploadToS3(bundleFilePath, s3Key);
 
                 // clean up the temporary working directory
                 Directory.Delete(tempWorkingDir, true);
@@ -1548,7 +1569,7 @@ namespace hasheous_server.Controllers.v1_0
             await System.IO.File.WriteAllTextAsync(metadataFilePath, metadata);
         }
 
-        private async Task _AddFileToBundle(string tempBundleDir, string relativePathInBundle, PhysicalFileResult fileData)
+        private async Task _AddFileToBundle(string tempBundleDir, string relativePathInBundle, FileResult fileData, string fileNameHint)
         {
             // create the directory if it doesn't exist
             string fileDir = Path.Combine(tempBundleDir, relativePathInBundle);
@@ -1558,29 +1579,62 @@ namespace hasheous_server.Controllers.v1_0
                 Directory.CreateDirectory(fileDir);
             }
 
-            // PhysicalFileResult provides a physical path via FileName; copy from disk
-            string? sourcePath = fileData.FileName;
-            // Only use the basename for the bundle, not the full source path
-            string destFileName = Path.GetFileName(sourcePath ?? string.Empty);
-            string filePathInBundle = Path.Combine(fileDir, destFileName);
-            if (string.IsNullOrWhiteSpace(sourcePath) || !System.IO.File.Exists(sourcePath))
+            string destFileName = Path.GetFileName(fileNameHint);
+            if (string.IsNullOrWhiteSpace(destFileName))
             {
-                throw new FileNotFoundException("Source file for bundle not found.", sourcePath ?? "<null>");
+                destFileName = Guid.NewGuid().ToString("N");
             }
 
-            // Avoid copying a file onto itself
-            if (string.Equals(Path.GetFullPath(sourcePath), Path.GetFullPath(filePathInBundle), StringComparison.OrdinalIgnoreCase))
+            string filePathInBundle = Path.Combine(fileDir, destFileName);
+
+            if (fileData is PhysicalFileResult physicalFile)
             {
+                string? sourcePath = physicalFile.FileName;
+                if (string.IsNullOrWhiteSpace(sourcePath) || !System.IO.File.Exists(sourcePath))
+                {
+                    throw new FileNotFoundException("Source file for bundle not found.", sourcePath ?? "<null>");
+                }
+
+                // Avoid copying a file onto itself
+                if (string.Equals(Path.GetFullPath(sourcePath), Path.GetFullPath(filePathInBundle), StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
+                // copy the file data to the bundle
+                // Use explicit streams with read sharing to minimize "file in use" issues
+                using (var sourceStream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (var destStream = new FileStream(filePathInBundle, FileMode.Create, FileAccess.Write, FileShare.None))
+                {
+                    await sourceStream.CopyToAsync(destStream);
+                }
+
                 return;
             }
 
-            // copy the file data to the bundle
-            // Use explicit streams with read sharing to minimize "file in use" issues
-            using (var sourceStream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read))
-            using (var destStream = new FileStream(filePathInBundle, FileMode.Create, FileAccess.Write, FileShare.None))
+            if (fileData is FileStreamResult streamResult)
             {
-                await sourceStream.CopyToAsync(destStream);
+                Stream sourceStream = streamResult.FileStream;
+                if (sourceStream.CanSeek)
+                {
+                    sourceStream.Position = 0;
+                }
+
+                await using (var destStream = new FileStream(filePathInBundle, FileMode.Create, FileAccess.Write, FileShare.None))
+                {
+                    await sourceStream.CopyToAsync(destStream);
+                }
+
+                return;
             }
+
+            if (fileData is FileContentResult contentResult)
+            {
+                await System.IO.File.WriteAllBytesAsync(filePathInBundle, contentResult.FileContents);
+                return;
+            }
+
+            throw new InvalidOperationException($"Unsupported file result type for bundle input: {fileData.GetType().Name}");
         }
 
         #endregion MetadataBundles


### PR DESCRIPTION
- Implemented StorageFallbackResolver class to handle file stream resolution from local storage first, with S3 as a fallback.
- Introduced ResolvedContentStream class to encapsulate stream sources and their metadata.
- Added methods for resolving read streams and uploading local files to S3.
- Included error handling for missing files and zero-length entries.
- Ensured asynchronous disposal of streams to prevent resource leaks.