### PR TITLE
Refactor DownloadAndCacheAsync and enhance Screenscraper support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,7 @@ Use this to get productive fast. Follow the existing patterns in this repo over 
   - Redis (Valkey) provides caching if enabled (`Classes/RedisConnection`), otherwise an in-memory cache is used.
   - Metadata file caching now supports optional S3-compatible object storage fallback (including MinIO) via shared helpers in `hasheous-lib/Classes/S3StorageTools.cs` and `hasheous-lib/Classes/StorageFallbackResolver.cs`.
   - Metadata proxy image and bundle routes use local-disk first, then S3 fallback, and fail open: if S3 is unavailable they fall back to existing provider fetch/build behavior without surfacing S3 errors to clients.
+  - `ProxyCacheManager.DownloadAndCacheAsync(...)` now returns a tuple: `(ResolvedContentStream? ContentStream, string? LocalFilePath)`. Use `ContentStream` for responses and `LocalFilePath` when post-download cleanup is needed.
   - When serving cache reads from `ProxyCacheManager` (`ResolvedContentStream`), register the wrapper for response disposal (for example `HttpContext.Response.RegisterForDispose(resolvedStream)`) before returning `File(resolvedStream.Stream, ...)`; disposing only the inner stream can leak S3 response resources/file handles.
   - S3 uploads for newly downloaded/built files are scheduled on response completion (`HttpContext.Response.OnCompleted`) so client download latency is not blocked by object-store upload time.
   - Separation: the orchestration server exists to separate background tasks from the frontend web server. The frontend web server only services user requests; the orchestrator schedules and runs internal/background work (`QueueProcessor.QueueItems` in `service-orchestrator/Program.cs`). Note the orchestrator has no public endpoints, and should only be called by trusted web servers using the inter-host API key.
@@ -59,6 +60,7 @@ Use this to get productive fast. Follow the existing patterns in this repo over 
   - MCP endpoint route: `POST /api/v1/Mcp` (JSON-RPC over HTTP). Keep MCP internet-facing endpoints in `hasheous` (not `service-orchestrator`).
   - Discovery route: `GET /.well-known/mcp.json` for client/server discovery metadata.
   - Metadata proxy file routes (`IGDB/Image`, `TheGamesDB/Images`, `GiantBomb/a/uploads`, and `Bundles/{MetadataSourceName}/{GameID}.bundle`) may return either physical-file or stream-backed file results depending on cache source; do not assume `PhysicalFileResult` only when consuming these actions internally.
+  - Metadata bundle route valid sources are currently `IGDB`, `TheGamesDB`, and `Screenscraper`.
   - ScreenScraper proxy routes are exposed under metadata proxy:
     - `GET /api/v1/MetadataProxy/ScreenScraper/jeuInfos.php` supports `gameid` or hash lookup (`crc`, `md5`, `sha1`) and can return JSON or XML via `output`.
     - `GET /api/v1/MetadataProxy/ScreenScraper/systemesListe.php` returns cached/platform metadata from ScreenScraper integration.
@@ -274,6 +276,8 @@ If something is unclear or missing (e.g., additional services, tests, or new aut
   - `jeuInfos.php` response shaping (matching ScreenScraper style) with support for `gameid` and hash-based fallback lookup (`crc`/`md5`/`sha1`).
   - `systemesListe.php` for platform listing.
   - `media{endpoint}.php` for media passthrough with cache-first behavior via `ProxyCacheManager`.
+- Cache miss sentinel handling: when ScreenScraper media download succeeds but the cached payload is tiny (`ContentLength <= 7`), treat it as a provider "not found" marker, dispose stream, delete the cached local file, and return `404`.
+- Bundle support now includes ScreenScraper via `GET /api/v1/MetadataProxy/Bundles/Screenscraper/{GameID}.bundle`, with game metadata plus media files sourced from ScreenScraper payloads.
 - Sensitive ScreenScraper query credentials (`devid`, `devpassword`, `ssid`, `sspassword`, `softname`) are stripped from rewritten media URLs before responses are returned.
 
 ## SteamGridDB metadata

--- a/hasheous-lib/Classes/ProxyCacheManager.cs
+++ b/hasheous-lib/Classes/ProxyCacheManager.cs
@@ -131,7 +131,7 @@ namespace Classes
         /// Downloads a file from the given URL, stores it locally in the source-specific cache directory,
         /// and schedules an S3 upload on HTTP response completion (non-blocking for client).
         /// </summary>
-        public static async Task<ResolvedContentStream?> DownloadAndCacheAsync(
+        public static async Task<(ResolvedContentStream? ContentStream, string? LocalFilePath, string? S3Path)> DownloadAndCacheAsync(
             string downloadUrl,
             string sourceKey,
             string resourcePath,
@@ -156,7 +156,7 @@ namespace Classes
 
                 if (!downloadSuccess || !File.Exists(tempPath))
                 {
-                    return null;
+                    return (null, null, null);
                 }
 
                 // Validate file size > 0
@@ -164,7 +164,7 @@ namespace Classes
                 if (tempFileInfo.Length == 0)
                 {
                     File.Delete(tempPath);
-                    return null;
+                    return (null, null, null);
                 }
 
                 // Atomically move to final location
@@ -192,12 +192,12 @@ namespace Classes
                     ScheduleS3Upload(localFilePath, sourceKey, resourcePath, httpContext);
                 }
 
-                return result;
+                return (result, localFilePath, resourcePath);
             }
             catch (Exception ex)
             {
                 Logging.Log(Logging.LogType.Warning, "ProxyCacheManager", $"DownloadAndCacheAsync failed for {downloadUrl}: {ex.Message}");
-                return null;
+                return (null, null, null);
             }
         }
 

--- a/hasheous-lib/Classes/ProxyCacheManager.cs
+++ b/hasheous-lib/Classes/ProxyCacheManager.cs
@@ -131,7 +131,7 @@ namespace Classes
         /// Downloads a file from the given URL, stores it locally in the source-specific cache directory,
         /// and schedules an S3 upload on HTTP response completion (non-blocking for client).
         /// </summary>
-        public static async Task<(ResolvedContentStream? ContentStream, string? LocalFilePath, string? S3Path)> DownloadAndCacheAsync(
+        public static async Task<(ResolvedContentStream? ContentStream, string? LocalFilePath)> DownloadAndCacheAsync(
             string downloadUrl,
             string sourceKey,
             string resourcePath,
@@ -156,7 +156,7 @@ namespace Classes
 
                 if (!downloadSuccess || !File.Exists(tempPath))
                 {
-                    return (null, null, null);
+                    return (null, null);
                 }
 
                 // Validate file size > 0
@@ -164,7 +164,7 @@ namespace Classes
                 if (tempFileInfo.Length == 0)
                 {
                     File.Delete(tempPath);
-                    return (null, null, null);
+                    return (null, null);
                 }
 
                 // Atomically move to final location
@@ -192,12 +192,12 @@ namespace Classes
                     ScheduleS3Upload(localFilePath, sourceKey, resourcePath, httpContext);
                 }
 
-                return (result, localFilePath, resourcePath);
+                return (result, localFilePath);
             }
             catch (Exception ex)
             {
                 Logging.Log(Logging.LogType.Warning, "ProxyCacheManager", $"DownloadAndCacheAsync failed for {downloadUrl}: {ex.Message}");
-                return (null, null, null);
+                return (null, null);
             }
         }
 

--- a/hasheous/Controllers/V1.0/MetadataProxyController.cs
+++ b/hasheous/Controllers/V1.0/MetadataProxyController.cs
@@ -1462,6 +1462,8 @@ namespace hasheous_server.Controllers.v1_0
                 {
                     if (fileStream.ContentStream.ContentLength.HasValue && fileStream.ContentStream.ContentLength.Value <= 7)
                     {
+                        await fileStream.ContentStream.DisposeAsync();
+
                         if (System.IO.File.Exists(fileStream.LocalFilePath))
                         {
                             System.IO.File.Delete(fileStream.LocalFilePath);
@@ -1485,7 +1487,7 @@ namespace hasheous_server.Controllers.v1_0
         /// Get a metadata bundle by its ID. Bundles contain pre-packaged metadata and images for offline use.
         /// </summary>
         /// <param name="MetadataSourceName" example="IGDB" required="true">
-        /// The name of the metadata source (e.g., IGDB, TheGamesDB, GiantBomb)
+        /// The name of the metadata source (e.g., IGDB, TheGamesDB, Screenscraper)
         /// </param>
         /// <param name="GameID" example="12345" required="true">
         /// The unique identifier of the game within the specified metadata source

--- a/hasheous/Controllers/V1.0/MetadataProxyController.cs
+++ b/hasheous/Controllers/V1.0/MetadataProxyController.cs
@@ -538,9 +538,9 @@ namespace hasheous_server.Controllers.v1_0
 
                 // Download and cache the image
                 var fileStream = await ProxyCacheManager.DownloadAndCacheAsync(url, "IGDB", resourcePath, CachePolicyType.Media, "image/jpeg", HttpContext);
-                if (fileStream != null)
+                if (fileStream.ContentStream != null)
                 {
-                    return FileWithManagedStream(fileStream, "image/jpeg");
+                    return FileWithManagedStream(fileStream.ContentStream, "image/jpeg");
                 }
 
                 return NotFound();
@@ -592,9 +592,9 @@ namespace hasheous_server.Controllers.v1_0
 
                 // Download and cache the image
                 var fileStream = await ProxyCacheManager.DownloadAndCacheAsync(url, "TheGamesDB", resourcePath, CachePolicyType.Media, "image/jpeg", HttpContext);
-                if (fileStream != null)
+                if (fileStream.ContentStream != null)
                 {
-                    return FileWithManagedStream(fileStream, "image/jpeg");
+                    return FileWithManagedStream(fileStream.ContentStream, "image/jpeg");
                 }
 
                 return NotFound();
@@ -1172,9 +1172,9 @@ namespace hasheous_server.Controllers.v1_0
 
                 // Download and cache the image
                 var fileStream = await ProxyCacheManager.DownloadAndCacheAsync(url, "GiantBomb", resourcePath, CachePolicyType.Media, "image/jpeg", HttpContext);
-                if (fileStream != null)
+                if (fileStream.ContentStream != null)
                 {
-                    return FileWithManagedStream(fileStream, "image/jpeg");
+                    return FileWithManagedStream(fileStream.ContentStream, "image/jpeg");
                 }
 
                 return NotFound();
@@ -1458,9 +1458,17 @@ namespace hasheous_server.Controllers.v1_0
 
                 // Download and cache the image
                 var fileStream = await ProxyCacheManager.DownloadAndCacheAsync(url, "Screenscraper", resourcePath, CachePolicyType.Media, mimeType, HttpContext);
-                if (fileStream != null)
+                if (fileStream.ContentStream != null)
                 {
-                    return FileWithManagedStream(fileStream, mimeType);
+                    if (fileStream.ContentStream.ContentLength.HasValue && fileStream.ContentStream.ContentLength.Value <= 7)
+                    {
+                        if (System.IO.File.Exists(fileStream.LocalFilePath))
+                        {
+                            System.IO.File.Delete(fileStream.LocalFilePath);
+                        }
+                        return NotFound("Media not found for the specified game and system.");
+                    }
+                    return FileWithManagedStream(fileStream.ContentStream, mimeType);
                 }
 
                 return NotFound();
@@ -1507,10 +1515,10 @@ namespace hasheous_server.Controllers.v1_0
             }
 
             // validate MetadataSourceName
-            var validSources = new List<string> { "IGDB", "TheGamesDB", "GiantBomb" };
+            var validSources = new List<string> { "IGDB", "TheGamesDB", "Screenscraper" };
             if (!validSources.Contains(MetadataSourceName))
             {
-                return BadRequest("Invalid metadata source");
+                return BadRequest("Invalid metadata source. Valid sources are: " + string.Join(", ", validSources));
             }
 
             // check the disk for a pre-built bundle
@@ -1711,6 +1719,58 @@ namespace hasheous_server.Controllers.v1_0
                             }
                         }
 
+                        break;
+
+                    case "Screenscraper":
+                        var ssGameData = await GetScreenScraperResponse_Singular(long.Parse(GameID), null, null, null);
+                        // extract the response
+                        hasheous_server.Classes.MetadataLib.MetadataScreenScraper.ssGame? ssGameObj = null;
+                        if (ssGameData is OkObjectResult okResult3)
+                        {
+                            var payload = okResult3.Value as hasheous_server.Classes.MetadataLib.MetadataScreenScraper.GameItem;
+                            ssGameObj = payload?.response?.jeu;
+                            // serialize the ssGameObj to json
+                            string ssGameJson = Newtonsoft.Json.JsonConvert.SerializeObject(ssGameObj, Newtonsoft.Json.Formatting.Indented, new Newtonsoft.Json.JsonSerializerSettings
+                            {
+                                NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
+                                MaxDepth = 64
+                            });
+                            // drop the game metadata json file
+                            await _AddMetadataToBundle(tempWorkingDir, "Game", ssGameJson);
+
+                            // get all media items and add them to the bundle
+                            if (ssGameObj != null && ssGameObj.medias != null)
+                            {
+                                foreach (var media in ssGameObj.medias)
+                                {
+                                    string mediaType = media.type ?? "";
+                                    string mediaRegion = media.region ?? "";
+                                    string mediaFileName = $"{mediaType}";
+                                    if (!string.IsNullOrEmpty(mediaRegion))
+                                    {
+                                        mediaFileName += $"({mediaRegion})";
+                                    }
+                                    mediaFileName += $".{media.format ?? "jpg"}";
+
+                                    var mediaFileDataResponse = await GetScreenScraperMedia(mediaType, long.Parse(ssGameObj.systeme.id), (long)ssGameObj.id, mediaType);
+
+                                    if (mediaFileDataResponse is NotFoundObjectResult)
+                                    {
+                                        // skip if media not found
+                                        continue;
+                                    }
+
+                                    if (mediaFileDataResponse is FileResult mediaFileData)
+                                    {
+                                        await _AddFileToBundle(tempWorkingDir, media.parent ?? "medias", mediaFileData, mediaFileName);
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            return BadRequest();
+                        }
                         break;
                 }
 


### PR DESCRIPTION
Refactor the `DownloadAndCacheAsync` method to return a tuple containing the content stream, local file path, and S3 path. Update the `MetadataProxyController` to handle the new return type and add media validation specifically for Screenscraper. This improves media handling and ensures better error management.