### PR TITLE
Update MySqlConnector package and MSBuild target formatting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 		}
 	},
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "dotnet dev-certs https && dotnet restore",
+	"postCreateCommand": "dotnet dev-certs https && dotnet restore && dotnet tool install --global dotnet-outdated-tool",
 	// Configure tool-specific properties.
 	"customizations": {
 		"vscode": {

--- a/hasheous-cli/hasheous-cli.csproj
+++ b/hasheous-cli/hasheous-cli.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="MySqlConnector" Version="2.6.1" />
+    <PackageReference Include="MySqlConnector" Version="2.6.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/hasheous-lib.Tests/hasheous-lib.Tests.csproj
+++ b/hasheous-lib.Tests/hasheous-lib.Tests.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/hasheous-lib/hasheous-lib.csproj
+++ b/hasheous-lib/hasheous-lib.csproj
@@ -15,23 +15,23 @@
     <DocumentationFile>bin\Release\net10.0\hasheous-lib.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="4.0.101.6" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.102.1" />
     <PackageReference Include="craftersmine.SteamGridDB.Net" Version="1.1.7" />
-    <PackageReference Include="gaseous-signature-parser" Version="2.7.2" />
+    <PackageReference Include="gaseous-signature-parser" Version="2.7.3" />
     <PackageReference Include="gaseous.IGDB" Version="1.0.6" />
-    <PackageReference Include="hasheous-client" Version="1.5.3" />
+    <PackageReference Include="hasheous-client" Version="1.5.4" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="Asp.Versioning.Mvc" Version="10.0.1" />
-    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.10" />
-    <PackageReference Include="StackExchange.Redis" Version="3.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="10.2.1" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.2.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.11" />
+    <PackageReference Include="StackExchange.Redis" Version="3.1.13" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
-    <PackageReference Include="MySqlConnector" Version="2.6.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="MySqlConnector" Version="2.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
     <!-- <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" /> -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
@@ -42,7 +42,7 @@
     <None Remove="Schema\hasheous-*.sql" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="18.8.2" />
+    <PackageReference Include="Microsoft.Build" Version="18.9.6" />
     <EmbeddedResource Include="Support\*.txt" />
     <EmbeddedResource Include="Schema\hasheous-*.sql" />
   </ItemGroup>

--- a/service-orchestrator/service-orchestrator.csproj
+++ b/service-orchestrator/service-orchestrator.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySqlConnector" Version="2.6.1" />
+    <PackageReference Include="MySqlConnector" Version="2.6.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,9 +27,7 @@
   <Target Name="PublishAndMigrateServiceHost" BeforeTargets="BeforeBuild;Publish">
     
     <!-- FIX: Instruct MSBuild to run a focused standalone publish command for the child app -->
-    <MSBuild Projects="../service-host/service-host.csproj" 
-            Targets="Publish" 
-            Properties="Configuration=$(Configuration);Platform=$(Platform);PublishDir=$(TargetDir)service-host/" />
+    <MSBuild Projects="../service-host/service-host.csproj" Targets="Publish" Properties="Configuration=$(Configuration);Platform=$(Platform);PublishDir=$(TargetDir)service-host/" />
             
   </Target>
 </Project>


### PR DESCRIPTION
Upgrade the MySqlConnector package to version 2.6.2 and ensure the MSBuild target for service-host publish is correctly formatted. Additional package updates enhance compatibility and functionality across the project.