### PR TITLE
Add basic submission report

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,7 @@ Use this to get productive fast. Follow the existing patterns in this repo over 
   - Signature ingestion now stores game names from `SortingName` and includes a one-time per-parser migration flag (`HasMigratedToSortingName_<ParserType>`) to migrate legacy name records while preserving alternate-name mappings.
   - Signature game records now also persist country/language variants on `Signatures_Games` (`Country`, `Language`), and migration logic updates legacy null-country rows plus links variant rows back to existing `DataObject_SignatureMap` entries.
   - Public API (versioned) handles lookups like `POST /api/v1/Lookup/ByHash` via `Classes/HashLookup` + `Classes/Database`.
+  - Submission voting/reporting is handled by `hasheous-lib/Classes/Submissions.cs`: `AddVote(...)` resolves the target object by `DataObjectId` or hash lookup, validates source-specific IDs before inserting/updating `MatchUserVotes`, and `TallyVotes()` aggregates votes into the metadata map only when the vote threshold is reached and the metadata is not locked by manual/admin overrides.
   - Insights logging records request method, endpoint path, execution time, and status on `Insights_API_Requests`; aggregated hourly/daily/monthly tables must preserve `endpoint_address` and `method` so reports can rank the busiest endpoints and identify CPU hotspots.
   - MCP is hosted on the public `hasheous` web API at `POST /api/v1/Mcp` (controller: `hasheous/Controllers/V1.0/McpController.cs`; shared processor: `hasheous-lib/Classes/Mcp/McpRequestProcessor.cs`).
   - MCP discovery is published at `GET /.well-known/mcp.json` (controller: `hasheous/Controllers/WellKnownController.cs`) and should point clients to the hosted MCP endpoint.
@@ -64,6 +65,7 @@ Use this to get productive fast. Follow the existing patterns in this repo over 
   - Data object admin task endpoints are exposed on `DataObjectsController` for moderators/admins:
     - `GET /api/v1/DataObjects/{ObjectType}/{Id}/Tasks` returns all task records for the object.
     - `GET /api/v1/DataObjects/{ObjectType}/{Id}/Tasks/{TaskId}?resetTask=true` returns a single task and optionally resets it.
+  - Submission/reporting routes are also admin/moderator scoped: `GET /api/v1/DataObjects/{ObjectType}/{Id}/SubmissionReport` returns the current match-submission summary, and user submit flows live under `hasheous/Controllers/V1.0/SubmissionsController.cs` via `POST /api/v1/Submissions/FixMatch`.
   - Swagger is enabled with custom schema IDs and API key security definitions.
   - MCP endpoint route: `POST /api/v1/Mcp` (JSON-RPC over HTTP). Keep MCP internet-facing endpoints in `hasheous` (not `service-orchestrator`).
   - Discovery route: `GET /.well-known/mcp.json` for client/server discovery metadata.

--- a/hasheous-lib/Classes/Submissions.cs
+++ b/hasheous-lib/Classes/Submissions.cs
@@ -458,5 +458,47 @@ namespace hasheous_server.Classes
             // return the model with the archive details
             return model;
         }
+
+
+        /// <summary>
+        /// Returns all submissions for a given dataobject, including the metadata source, and the vote count for that submission
+        /// </summary>
+        /// <param name="DataObjectId">
+        /// The ID of the dataobject to generate the report for
+        /// </param>
+        /// <returns>
+        /// A list of SubmissionReportItem objects, each containing the metadata source, the metadata game ID, and the vote count for that submission
+        /// </returns>
+        public static async Task<List<SubmissionReportItem>> GenerateSubmissionReport(long DataObjectId)
+        {
+            Database db = new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString);
+
+            string sql = "SELECT MetadataSourceId, MetadataGameId, COUNT(*) AS VoteCount FROM MatchUserVotes WHERE DataObjectId = @dataObjectId GROUP BY MetadataSourceId, MetadataGameId ORDER BY MetadataSourceId, VoteCount DESC;";
+            DataTable data = await db.ExecuteCMDAsync(sql, new Dictionary<string, object>
+            {
+                { "dataObjectId", DataObjectId }
+            });
+
+            List<SubmissionReportItem> reportItems = new List<SubmissionReportItem>();
+
+            foreach (DataRow row in data.Rows)
+            {
+                reportItems.Add(new SubmissionReportItem
+                {
+                    MetadataSource = (Communications.MetadataSources)(long)row["MetadataSourceId"],
+                    MetadataGameId = row["MetadataGameId"].ToString(),
+                    VoteCount = (int)(long)row["VoteCount"]
+                });
+            }
+
+            return reportItems;
+        }
+
+        public class SubmissionReportItem
+        {
+            public Communications.MetadataSources MetadataSource { get; set; }
+            public string MetadataGameId { get; set; }
+            public int VoteCount { get; set; }
+        }
     }
 }

--- a/hasheous-lib/Classes/Submissions.cs
+++ b/hasheous-lib/Classes/Submissions.cs
@@ -485,7 +485,7 @@ namespace hasheous_server.Classes
             {
                 reportItems.Add(new SubmissionReportItem
                 {
-                    MetadataSource = (Communications.MetadataSources)(long)row["MetadataSourceId"],
+                    MetadataSource = (Communications.MetadataSources)(int)row["MetadataSourceId"],
                     MetadataGameId = row["MetadataGameId"].ToString(),
                     VoteCount = (int)(long)row["VoteCount"]
                 });

--- a/hasheous/Controllers/V1.0/DataObjectController.cs
+++ b/hasheous/Controllers/V1.0/DataObjectController.cs
@@ -516,7 +516,7 @@ namespace hasheous_server.Controllers.v1_0
         {
             hasheous_server.Classes.DataObjects DataObjects = new Classes.DataObjects();
 
-            Models.DataObjectItem? DataObject = await DataObjects.GetDataObject(ObjectType, Id);
+            Models.DataObjectItem? DataObject = await DataObjects.GetDataObject(ObjectType, Id, false, false, false);
 
             if (DataObject == null)
             {

--- a/hasheous/Controllers/V1.0/DataObjectController.cs
+++ b/hasheous/Controllers/V1.0/DataObjectController.cs
@@ -508,6 +508,27 @@ namespace hasheous_server.Controllers.v1_0
         }
 
         [MapToApiVersion("1.0")]
+        [HttpGet]
+        [Authorize(Roles = "Admin,Moderator")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [Route("{ObjectType}/{Id}/SubmissionReport")]
+        public async Task<IActionResult> GetDataObjectSubmissionReport(Classes.DataObjects.DataObjectType ObjectType, long Id)
+        {
+            hasheous_server.Classes.DataObjects DataObjects = new Classes.DataObjects();
+
+            Models.DataObjectItem? DataObject = await DataObjects.GetDataObject(ObjectType, Id);
+
+            if (DataObject == null)
+            {
+                return NotFound();
+            }
+            else
+            {
+                return Ok(await Submissions.GenerateSubmissionReport(Id));
+            }
+        }
+
+        [MapToApiVersion("1.0")]
         [HttpPost]
         [Authorize(Roles = "Admin,Moderator")]
         [ProducesResponseType(StatusCodes.Status200OK)]


### PR DESCRIPTION
Mods and Admins can query `/api/v1/DataObjects/<objectType>/<objectId>/SubmissionReport` to receive a basic report of what users have submitted to Hasheous.