### PR TITLE
Enhance rate limiter security and sanitization

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,7 +47,10 @@ Use this to get productive fast. Follow the existing patterns in this repo over 
 
 - Configuration
   - File: `~/.hasheous-server/config.json` (auto-updated on startup by `Config.UpdateConfig()`). Env vars (used by Docker): `dbhost`, `dbuser`, `dbpass`, `igdbclientid`, `igdbclientsecret`, `redisenabled`, `redishost`, `redisport`, `reportingserverurl`, etc.
-  - Dynamic request rate-limiter rules live in a separate file at `~/.hasheous-server/rate-limit-rules.json` and are reloaded every 5 minutes without restarting the server.
+  - Dynamic request rate-limiter rules live in a separate file at `~/.hasheous-server/rate-limit-rules.json` (via `Config.RateLimitRulesFilePath`) and are reloaded every 5 minutes without restarting the server.
+  - Rate-limit rule sets are sanitized on load: invalid or empty profiles are normalized, defaults are supplied, `PartitionBy` falls back to `remote-ip`, and the last known-good rules stay active if the file cannot be parsed.
+  - Built-in webpage requests are exempt by design via a protected cookie + DPAPI-backed 7-day web session marker; API traffic must match explicit rate-limit profiles instead.
+  - Rate-limit profile matching supports `remote-ip`, `origin`, `user-agent`, `path`, `method`, `user-id`, `user-roles`, and `header:<name>` partition keys, and rule matches use wildcard-safe pattern parsing rather than raw regex injection.
   - S3 config (`Config.S3StorageConfiguration`): `Enabled`, `Region`, `ServiceUrl`, `AccessKey`, `SecretKey`, `SessionToken`, `ForcePathStyle`, `DefaultBucket`.
   - Tiered cache policy config (`Config.CachePolicies` / config field `Policies`) controls proxy cache retention by content type and storage tier:
     - `Media`: local tier defaults to size-only retention; S3 tier defaults to 2-year max age.
@@ -93,6 +96,7 @@ Use this to get productive fast. Follow the existing patterns in this repo over 
   - User key header `X-API-Key` via `[Authentication.ApiKey.ApiKeyAttribute]` (`ApiKeyAuthorizationFilter` wired in `hasheous/Program.cs`) — identifies individual users and their actions.
   - Client key header `X-Client-API-Key` via `[Authentication.ClientApiKey.ClientApiKeyAttribute]` — identifies client apps (e.g., Gaseous, Romm); typically required when `Config.RequireClientAPIKey` is true.
   - MVC/API request rate limiting is enforced by the shared dynamic limiter in `hasheous-lib/Classes/RateLimiting/RequestRateLimiting.cs`; built-in webpage requests are always exempt and profiles can match on roles, origin, user agent, remote IP, and arbitrary headers from `rate-limit-rules.json`.
+  - The rate limiter uses a sanitized ruleset, wildcard-safe pattern matching, and 429 responses with `Retry-After` metadata when a profile is exhausted; do not add untrusted regex patterns or mutate a live rules file without validating it first.
   - To exempt specific endpoints from client API key requirement, use `[Authentication.ClientApiKey.NoClientApiKeyNeededAttribute]` on the method. This is useful for public media endpoints that should not require authentication.
   - Inter-host API key for orchestrator calls (see `InterHostApiKey*` and registration in `service-orchestrator/Program.cs`) — security mechanism allowing multiple web server frontends (load-balanced) to securely call the orchestrator.
   - Admin user list endpoints should avoid per-user role lookups. Prefer a single grouped query against `Users`/`UserRoles`/`Roles`, cache the result briefly in Redis, and invalidate that cache after role mutations.

--- a/hasheous-lib/Classes/Config.cs
+++ b/hasheous-lib/Classes/Config.cs
@@ -57,6 +57,14 @@ namespace Classes
             }
         }
 
+        public static string[] TrustedHosts
+        {
+            get
+            {
+                return _config.TrustedHosts;
+            }
+        }
+
         /// <summary>
         /// Gets the database configuration settings.
         /// </summary>
@@ -600,6 +608,11 @@ namespace Classes
             /// Gets or sets the Redis cache configuration settings.
             /// </summary>
             public Redis RedisConfiguration = new Redis();
+
+            /// <summary>
+            /// Gets or sets the host names to exempt from rate limiting
+            /// </summary>
+            public string[] TrustedHosts = Array.Empty<string>();
 
             /// <summary>
             /// Gets or sets the library configuration settings, including paths for metadata, uploads, and dumps.

--- a/hasheous-lib/Classes/RateLimiting/RequestRateLimiting.cs
+++ b/hasheous-lib/Classes/RateLimiting/RequestRateLimiting.cs
@@ -222,7 +222,7 @@ public class DynamicRateLimitManager : BackgroundService
                 var newLimiters = new ConcurrentDictionary<string, FixedWindowRateLimiter>(StringComparer.Ordinal);
 
                 // check for if newLimiters is different from oldLimiters
-                if (!hashObject.Equals(_hashObject))
+                if (hashObject.sha1hash != _hashObject.sha1hash)
                 {
                     _hashObject = hashObject;
                     _limiters = newLimiters;

--- a/hasheous-lib/Classes/RateLimiting/RequestRateLimiting.cs
+++ b/hasheous-lib/Classes/RateLimiting/RequestRateLimiting.cs
@@ -108,6 +108,7 @@ public class DynamicRateLimitManager : BackgroundService
     };
     private readonly TimeSpan _reloadInterval;
     private readonly string _rulesFilePath;
+    private Common.hashObject _hashObject = new();
     private readonly object _reloadLock = new();
     private readonly IDataProtector? _webRequestProtector;
     private readonly IServiceScopeFactory? _serviceScopeFactory;
@@ -212,17 +213,25 @@ public class DynamicRateLimitManager : BackgroundService
             {
                 EnsureRulesFileExists();
                 string rawRules = File.ReadAllText(_rulesFilePath);
+                Common.hashObject hashObject = new(_rulesFilePath);
                 RateLimitRuleSet? parsedRules = JsonSerializer.Deserialize<RateLimitRuleSet>(rawRules, SerializerOptions);
                 _rules = Sanitize(parsedRules ?? new RateLimitRuleSet());
                 _patternCache = new ConcurrentDictionary<string, Regex>(StringComparer.Ordinal);
 
                 ConcurrentDictionary<string, FixedWindowRateLimiter> oldLimiters = _limiters;
-                _limiters = new ConcurrentDictionary<string, FixedWindowRateLimiter>(StringComparer.Ordinal);
-                Interlocked.Increment(ref _rulesVersion);
+                var newLimiters = new ConcurrentDictionary<string, FixedWindowRateLimiter>(StringComparer.Ordinal);
 
-                foreach (FixedWindowRateLimiter limiter in oldLimiters.Values)
+                // check for if newLimiters is different from oldLimiters
+                if (!hashObject.Equals(_hashObject))
                 {
-                    limiter.Dispose();
+                    _hashObject = hashObject;
+                    _limiters = newLimiters;
+                    Interlocked.Increment(ref _rulesVersion);
+
+                    foreach (FixedWindowRateLimiter limiter in oldLimiters.Values)
+                    {
+                        limiter.Dispose();
+                    }
                 }
             }
             catch (Exception ex)

--- a/hasheous-lib/Classes/RateLimiting/RequestRateLimiting.cs
+++ b/hasheous-lib/Classes/RateLimiting/RequestRateLimiting.cs
@@ -480,8 +480,14 @@ public class DynamicRateLimitManager : BackgroundService
 
     private static RateLimitRuleSet Sanitize(RateLimitRuleSet rules)
     {
+        rules.Profiles ??= new List<RateLimitProfile>();
+
         foreach (RateLimitProfile profile in rules.Profiles)
         {
+            profile.Match ??= new RateLimitMatchCriteria();
+            profile.FixedWindow ??= new FixedWindowRateLimitSettings();
+            profile.PartitionBy ??= new List<string>();
+
             profile.Name = string.IsNullOrWhiteSpace(profile.Name) ? $"Profile-{Guid.NewGuid():N}" : profile.Name.Trim();
             profile.PartitionBy = profile.PartitionBy.Count == 0 ? new List<string> { "remote-ip" } : profile.PartitionBy;
             profile.FixedWindow.PermitLimit = Math.Max(1, profile.FixedWindow.PermitLimit);

--- a/hasheous-lib/Classes/RateLimiting/RequestRateLimiting.cs
+++ b/hasheous-lib/Classes/RateLimiting/RequestRateLimiting.cs
@@ -493,6 +493,12 @@ public class DynamicRateLimitManager : BackgroundService
             profile.FixedWindow.PermitLimit = Math.Max(1, profile.FixedWindow.PermitLimit);
             profile.FixedWindow.WindowSeconds = Math.Max(1, profile.FixedWindow.WindowSeconds);
             profile.FixedWindow.QueueLimit = Math.Max(0, profile.FixedWindow.QueueLimit);
+            profile.Match.Methods ??= new List<string>();
+            profile.Match.Paths ??= new List<string>();
+            profile.Match.Origins ??= new List<string>();
+            profile.Match.UserAgents ??= new List<string>();
+            profile.Match.RemoteIps ??= new List<string>();
+            profile.Match.UserRoles ??= new List<string>();
             profile.Match.Headers ??= new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         }
 

--- a/hasheous/StartupExtensions.cs
+++ b/hasheous/StartupExtensions.cs
@@ -379,24 +379,30 @@ public static class StartupExtensions
             if (!context.Request.Path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase)
                 && (HttpMethods.IsGet(context.Request.Method) || HttpMethods.IsHead(context.Request.Method)))
             {
-                // Modern browsers explicitly flag the origin of the request
-                string secFetchSite = context.Request.Headers["Sec-Fetch-Site"];
-                bool isSameOrigin = secFetchSite == "same-origin";
+                // Modern browsers set Sec-Fetch-Site on all fetches.
+                // "same-origin" = in-page navigation; "none" = top-level direct navigation
+                // (address bar, bookmark, external link). Both represent a legitimate browser
+                // request to serve a built-in page.
+                string secFetchSite = context.Request.Headers["Sec-Fetch-Site"].ToString();
+                bool issueMarker = secFetchSite == "same-origin" || secFetchSite == "none";
 
-                // Fallback check for older browsers using the Referer header
-                if (!isSameOrigin && context.Request.Headers.TryGetValue("Referer", out var referer))
+                // If Sec-Fetch-Site is absent (older browsers), fall back to the Referer header.
+                if (!issueMarker && string.IsNullOrEmpty(secFetchSite))
                 {
-                    if (Uri.TryCreate(referer, UriKind.Absolute, out var refererUri))
+                    if (context.Request.Headers.TryGetValue("Referer", out var referer)
+                        && Uri.TryCreate(referer, UriKind.Absolute, out var refererUri))
                     {
-                        // Verify the request actually came from hasheous.org
-                        if (Config.TrustedHosts != null && Config.TrustedHosts.Length > 0)
-                        {
-                            isSameOrigin = Config.TrustedHosts.Contains(refererUri.Host, StringComparer.OrdinalIgnoreCase);
-                        }
+                        issueMarker = Config.TrustedHosts.Contains(refererUri.Host, StringComparer.OrdinalIgnoreCase);
+                    }
+                    else
+                    {
+                        // No Sec-Fetch-Site and no Referer — could be a direct navigation on an
+                        // older browser. Issue the marker so built-in pages are not rate-limited.
+                        issueMarker = true;
                     }
                 }
 
-                if (isSameOrigin)
+                if (issueMarker)
                 {
                     DynamicRateLimitManager dynamicRateLimitManager = context.RequestServices.GetRequiredService<DynamicRateLimitManager>();
                     dynamicRateLimitManager.IssueWebRequestCookie(context);

--- a/hasheous/StartupExtensions.cs
+++ b/hasheous/StartupExtensions.cs
@@ -1,6 +1,6 @@
 using System.Linq;
-using System.Net.Http.Headers;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Mail;
 using System.Reflection;
 using System.Security.Claims;
@@ -379,8 +379,25 @@ public static class StartupExtensions
             if (!context.Request.Path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase)
                 && (HttpMethods.IsGet(context.Request.Method) || HttpMethods.IsHead(context.Request.Method)))
             {
-                DynamicRateLimitManager dynamicRateLimitManager = context.RequestServices.GetRequiredService<DynamicRateLimitManager>();
-                dynamicRateLimitManager.IssueWebRequestCookie(context);
+                // Modern browsers explicitly flag the origin of the request
+                string secFetchSite = context.Request.Headers["Sec-Fetch-Site"];
+                bool isSameOrigin = secFetchSite == "same-origin";
+
+                // Fallback check for older browsers using the Referer header
+                if (!isSameOrigin && context.Request.Headers.TryGetValue("Referer", out var referer))
+                {
+                    if (Uri.TryCreate(referer, UriKind.Absolute, out var refererUri))
+                    {
+                        // Verify the request actually came from hasheous.org
+                        isSameOrigin = Config.TrustedHosts.Contains(refererUri.Host, StringComparer.OrdinalIgnoreCase);
+                    }
+                }
+
+                if (isSameOrigin)
+                {
+                    DynamicRateLimitManager dynamicRateLimitManager = context.RequestServices.GetRequiredService<DynamicRateLimitManager>();
+                    dynamicRateLimitManager.IssueWebRequestCookie(context);
+                }
             }
 
             await next();

--- a/hasheous/StartupExtensions.cs
+++ b/hasheous/StartupExtensions.cs
@@ -389,7 +389,10 @@ public static class StartupExtensions
                     if (Uri.TryCreate(referer, UriKind.Absolute, out var refererUri))
                     {
                         // Verify the request actually came from hasheous.org
-                        isSameOrigin = Config.TrustedHosts.Contains(refererUri.Host, StringComparer.OrdinalIgnoreCase);
+                        if (Config.TrustedHosts != null && Config.TrustedHosts.Length > 0)
+                        {
+                            isSameOrigin = Config.TrustedHosts.Contains(refererUri.Host, StringComparer.OrdinalIgnoreCase);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Improve the security of the website's rate limiter by adding null guards to the rules sanitization function and implementing a more secure exemption for trusted hosts. This addresses feedback from a previous discussion.