### PR TITLE
Standardise hash lookup limits and restore functionality

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -87,7 +87,7 @@ Use this to get productive fast. Follow the existing patterns in this repo over 
     - `GET /api/v1/MetadataProxy/ScreenScraper/systemesListe.php` returns cached/platform metadata from ScreenScraper integration. Requires `X-Client-API-Key`.
     - `GET /api/v1/MetadataProxy/ScreenScraper/media{endpoint}.php` proxies/caches media and rejects traversal-like media IDs. Does NOT require `X-Client-API-Key`.
   - MCP lookups are intentionally public: the hosted MCP controller uses `[AllowAnonymous]` rather than API key auth.
-  - Hash lookup endpoints (`POST /api/v1/Lookup/ByHash`) enforce request payload limits: `MaxLookupPayloadBytes = 262_144` (256 KB) and `MaxLookupArrayItems = 50`. These are enforced via `[RequestSizeLimit]` and manual JSON array size validation before database queries run.
+  - Hash lookup endpoints (`POST /api/v1/Lookup/ByHash`) enforce request payload limits: `MaxLookupPayloadBytes = 262_144` (256 KB) and `MaxLookupArrayItems = 40`. These are enforced via `[RequestSizeLimit]` and manual JSON array size validation before database queries run.
   - Hash lookup responses use a layered caching model: the ASP.NET action is decorated with a short `[ResponseCache(CacheProfileName = "5Minute")]`, while expensive signature resolution is cached in Redis at the `SignatureManagement` layer. Keep the HTTP cache in place for repeated identical reads, and avoid forcing `All` metadata expansion on list/search callers when a minimal result payload is sufficient.
 
 - Auth & security
@@ -450,7 +450,7 @@ Additional example (rating boards):
 - For incremental async cleanup, update method signatures and call chains together in one change so no mixed sync/async regressions are introduced.
 
 ### Hash lookup request validation (current)
-- `POST /api/v1/Lookup/ByHash` now enforces request payload limits: `MaxLookupPayloadBytes = 262_144` (256 KB) via `[RequestSizeLimit]` and `MaxLookupArrayItems = 50` for the number of hash objects in the request body.
+- `POST /api/v1/Lookup/ByHash` now enforces request payload limits: `MaxLookupPayloadBytes = 262_144` (256 KB) via `[RequestSizeLimit]` and `MaxLookupArrayItems = 40` for the number of hash objects in the request body.
 - Zero-byte hashes are rejected with `400 Bad Request` for known hashes: MD5 `d41d8cd98f00b204e9800998ecf8427e`, SHA1 `da39a3ee5e6b4b0d3255bfef95601890afd80709`, SHA256 `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`, CRC `00000000`.
 - Request body JSON parsing uses `JsonSerializerOptions` with `PropertyNameCaseInsensitive = true` to normalize input.
 - Validation occurs before any database lookups to fail fast on invalid input.

--- a/hasheous/Controllers/V1.0/LookupController.cs
+++ b/hasheous/Controllers/V1.0/LookupController.cs
@@ -23,7 +23,7 @@ namespace hasheous_server.Controllers.v1_0
         private const string zeroByteSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
         private const string zeroByteCRC = "00000000";
         private const int MaxLookupPayloadBytes = 262_144;
-        private const int MaxLookupArrayItems = 50;
+        private const int MaxLookupArrayItems = 10;
 
         private static readonly JsonSerializerOptions HashLookupJsonOptions = new JsonSerializerOptions
         {

--- a/hasheous/Controllers/V1.0/LookupController.cs
+++ b/hasheous/Controllers/V1.0/LookupController.cs
@@ -235,7 +235,6 @@ namespace hasheous_server.Controllers.v1_0
         [Route("ByHash/crc/{crc}")]
         public async Task<IActionResult> LookupGet(string? md5, string? sha1, string? sha256, string? crc)
         {
-            //c convert the input to a list of HashLookupModel for consistency with the POST method and pass it to the LookupPost method
             var modelList = new List<HashLookupModel>
             {
                 new HashLookupModel { MD5 = md5, SHA1 = sha1, SHA256 = sha256, CRC = crc }

--- a/hasheous/Controllers/V1.0/LookupController.cs
+++ b/hasheous/Controllers/V1.0/LookupController.cs
@@ -23,7 +23,7 @@ namespace hasheous_server.Controllers.v1_0
         private const string zeroByteSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
         private const string zeroByteCRC = "00000000";
         private const int MaxLookupPayloadBytes = 262_144;
-        private const int MaxLookupArrayItems = 10;
+        private const int MaxLookupArrayItems = 40;
 
         private static readonly JsonSerializerOptions HashLookupJsonOptions = new JsonSerializerOptions
         {

--- a/hasheous/Controllers/V1.0/LookupController.cs
+++ b/hasheous/Controllers/V1.0/LookupController.cs
@@ -68,101 +68,106 @@ namespace hasheous_server.Controllers.v1_0
         [Route("ByHash")]
         public async Task<IActionResult> LookupPost(bool? returnAllSources = false, string? returnFields = "All", string? returnSources = null)
         {
-            try
-            {
-                List<gaseous_signature_parser.models.RomSignatureObject.RomSignatureObject.Game.Rom.SignatureSourceType> returnSourcesList = new List<gaseous_signature_parser.models.RomSignatureObject.RomSignatureObject.Game.Rom.SignatureSourceType>();
+            List<gaseous_signature_parser.models.RomSignatureObject.RomSignatureObject.Game.Rom.SignatureSourceType> returnSourcesList = new List<gaseous_signature_parser.models.RomSignatureObject.RomSignatureObject.Game.Rom.SignatureSourceType>();
 
-                if (returnSources != null)
+            if (returnSources != null)
+            {
+                string[] sources = returnSources.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                foreach (string source in sources)
                 {
-                    string[] sources = returnSources.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-                    foreach (string source in sources)
+                    if (Enum.TryParse<gaseous_signature_parser.models.RomSignatureObject.RomSignatureObject.Game.Rom.SignatureSourceType>(source, true, out var sourceType))
                     {
-                        if (Enum.TryParse<gaseous_signature_parser.models.RomSignatureObject.RomSignatureObject.Game.Rom.SignatureSourceType>(source, true, out var sourceType))
-                        {
-                            returnSourcesList.Add(sourceType);
-                        }
-                        else
-                        {
-                            Logging.Log(Logging.LogType.Warning, "Hash Lookup", $"Invalid source type provided: {source}");
-                            return BadRequest($"Invalid source type provided: {source}");
-                        }
+                        returnSourcesList.Add(sourceType);
+                    }
+                    else
+                    {
+                        Logging.Log(Logging.LogType.Warning, "Hash Lookup", $"Invalid source type provided: {source}");
+                        return BadRequest($"Invalid source type provided: {source}");
                     }
                 }
+            }
 
-                if (Request.ContentLength.HasValue && Request.ContentLength.Value > MaxLookupPayloadBytes)
-                {
-                    return StatusCode(StatusCodes.Status413PayloadTooLarge, $"Payload exceeds the maximum allowed size of {MaxLookupPayloadBytes / 1024}KB.");
-                }
+            if (Request.ContentLength.HasValue && Request.ContentLength.Value > MaxLookupPayloadBytes)
+            {
+                return StatusCode(StatusCodes.Status413PayloadTooLarge, $"Payload exceeds the maximum allowed size of {MaxLookupPayloadBytes / 1024}KB.");
+            }
 
-                // [{"crc": "12ec7f82"}, {"crc": "836a0187"}]
-                List<hasheous_server.Models.HashLookupModel> modelList = new List<hasheous_server.Models.HashLookupModel>();
-                JsonElement normalizedModel;
+            // [{"crc": "12ec7f82"}, {"crc": "836a0187"}]
+            List<hasheous_server.Models.HashLookupModel> modelList = new List<hasheous_server.Models.HashLookupModel>();
+            JsonElement normalizedModel;
 
-                if (Request.Body == null || (Request.ContentLength.HasValue && Request.ContentLength.Value == 0))
+            if (Request.Body == null || (Request.ContentLength.HasValue && Request.ContentLength.Value == 0))
+            {
+                return BadRequest("Invalid model payload. Provide a JSON object or array containing hash fields.");
+            }
+
+            try
+            {
+                using JsonDocument parsedBody = await JsonDocument.ParseAsync(Request.Body);
+                normalizedModel = parsedBody.RootElement.Clone();
+            }
+            catch (JsonException)
+            {
+                return BadRequest("Invalid model payload. Body must be valid JSON.");
+            }
+
+            // Some clients send JSON text as a quoted string (for example, "[{...}]").
+            // Parse the inner JSON so both raw and string-encoded JSON are accepted.
+            if (normalizedModel.ValueKind == JsonValueKind.String)
+            {
+                string? rawModelString = normalizedModel.GetString();
+                if (string.IsNullOrWhiteSpace(rawModelString))
                 {
                     return BadRequest("Invalid model payload. Provide a JSON object or array containing hash fields.");
                 }
 
                 try
                 {
-                    using JsonDocument parsedBody = await JsonDocument.ParseAsync(Request.Body);
-                    normalizedModel = parsedBody.RootElement.Clone();
+                    using JsonDocument parsedStringModel = JsonDocument.Parse(rawModelString);
+                    normalizedModel = parsedStringModel.RootElement.Clone();
                 }
                 catch (JsonException)
                 {
-                    return BadRequest("Invalid model payload. Body must be valid JSON.");
+                    return BadRequest("Invalid model payload. String body must contain valid JSON object or array text.");
                 }
+            }
 
-                // Some clients send JSON text as a quoted string (for example, "[{...}]").
-                // Parse the inner JSON so both raw and string-encoded JSON are accepted.
-                if (normalizedModel.ValueKind == JsonValueKind.String)
+            // Accept raw JSON object or array in request body and deserialize manually.
+            try
+            {
+                if (normalizedModel.ValueKind == JsonValueKind.Array)
                 {
-                    string? rawModelString = normalizedModel.GetString();
-                    if (string.IsNullOrWhiteSpace(rawModelString))
+                    modelList = JsonSerializer.Deserialize<List<hasheous_server.Models.HashLookupModel>>(normalizedModel, HashLookupJsonOptions) ?? new List<hasheous_server.Models.HashLookupModel>();
+                    if (modelList.Count > MaxLookupArrayItems)
                     {
-                        return BadRequest("Invalid model payload. Provide a JSON object or array containing hash fields.");
-                    }
-
-                    try
-                    {
-                        using JsonDocument parsedStringModel = JsonDocument.Parse(rawModelString);
-                        normalizedModel = parsedStringModel.RootElement.Clone();
-                    }
-                    catch (JsonException)
-                    {
-                        return BadRequest("Invalid model payload. String body must contain valid JSON object or array text.");
+                        return BadRequest($"Invalid model payload. A maximum of {MaxLookupArrayItems} hash items is allowed.");
                     }
                 }
-
-                // Accept raw JSON object or array in request body and deserialize manually.
-                try
+                else if (normalizedModel.ValueKind == JsonValueKind.Object)
                 {
-                    if (normalizedModel.ValueKind == JsonValueKind.Array)
+                    var deserializedModel = JsonSerializer.Deserialize<hasheous_server.Models.HashLookupModel>(normalizedModel, HashLookupJsonOptions);
+                    if (deserializedModel != null)
                     {
-                        modelList = JsonSerializer.Deserialize<List<hasheous_server.Models.HashLookupModel>>(normalizedModel, HashLookupJsonOptions) ?? new List<hasheous_server.Models.HashLookupModel>();
-                        if (modelList.Count > MaxLookupArrayItems)
-                        {
-                            return BadRequest($"Invalid model payload. A maximum of {MaxLookupArrayItems} hash items is allowed.");
-                        }
-                    }
-                    else if (normalizedModel.ValueKind == JsonValueKind.Object)
-                    {
-                        var deserializedModel = JsonSerializer.Deserialize<hasheous_server.Models.HashLookupModel>(normalizedModel, HashLookupJsonOptions);
-                        if (deserializedModel != null)
-                        {
-                            modelList.Add(deserializedModel);
-                        }
-                    }
-                    else
-                    {
-                        return BadRequest("Invalid model payload. Provide a JSON object or array containing hash fields.");
+                        modelList.Add(deserializedModel);
                     }
                 }
-                catch (JsonException)
+                else
                 {
-                    return BadRequest("Invalid model payload. Unable to deserialize request body into hash lookup model(s).");
+                    return BadRequest("Invalid model payload. Provide a JSON object or array containing hash fields.");
                 }
+            }
+            catch (JsonException)
+            {
+                return BadRequest("Invalid model payload. Unable to deserialize request body into hash lookup model(s).");
+            }
 
+            return await LookupPostInternal(modelList, returnAllSources, returnFields, returnSourcesList);
+        }
+
+        private async Task<IActionResult> LookupPostInternal(List<HashLookupModel> modelList, bool? returnAllSources, string? returnFields, List<gaseous_signature_parser.models.RomSignatureObject.RomSignatureObject.Game.Rom.SignatureSourceType> returnSourcesList)
+        {
+            try
+            {
                 // Drop known zero-byte hashes before lookup to avoid unnecessary work.
                 modelList = modelList.Where(x => !IsKnownZeroByteHash(x)).ToList();
 
@@ -230,43 +235,14 @@ namespace hasheous_server.Controllers.v1_0
         [Route("ByHash/crc/{crc}")]
         public async Task<IActionResult> LookupGet(string? md5, string? sha1, string? sha256, string? crc)
         {
-            // fail on obvious zero byte hashes to avoid unnecessary lookups
-            if (md5 == zeroByteMD5 || sha1 == zeroByteSHA1 || sha256 == zeroByteSHA256 || crc == zeroByteCRC)
+            //c convert the input to a list of HashLookupModel for consistency with the POST method and pass it to the LookupPost method
+            var modelList = new List<HashLookupModel>
             {
-                return BadRequest("Invalid hash provided. Zero-byte hashes are not allowed.");
-            }
+                new HashLookupModel { MD5 = md5, SHA1 = sha1, SHA256 = sha256, CRC = crc }
+            };
 
-            try
-            {
-                HashLookup hashLookup = new HashLookup(new Database(Database.databaseType.MySql, Config.DatabaseConfiguration.ConnectionString), new List<hasheous_server.Models.HashLookupModel>
-                {
-                    new hasheous_server.Models.HashLookupModel
-                    {
-                        MD5 = md5,
-                        SHA1 = sha1,
-                        SHA256 = sha256,
-                        CRC = crc
-                    }
-                });
-                await hashLookup.PerformLookup();
-
-                if (hashLookup == null)
-                {
-                    return NotFound();
-                }
-                else
-                {
-                    return Ok(hashLookup);
-                }
-            }
-            catch (HashLookup.HashNotFoundException)
-            {
-                return NotFound("The provided hash was not found in the signature database.");
-            }
-            catch
-            {
-                return NotFound();
-            }
+            // Call the LookupPost method with the constructed model list
+            return await LookupPostInternal(modelList, false, "All", new List<gaseous_signature_parser.models.RomSignatureObject.RomSignatureObject.Game.Rom.SignatureSourceType>());
         }
 
         /// <summary>


### PR DESCRIPTION
Standardise the maximum number of hashes allowed in a single lookup to 40 and restore previous code functionality. Adjustments ensure consistent behavior across hash lookup endpoints.